### PR TITLE
working bfs traversal algorithm

### DIFF
--- a/algos.cpp
+++ b/algos.cpp
@@ -247,10 +247,10 @@ void testAlgHeuristics(std::vector<Station> stations, std::vector<int> goal,
     std::vector<int> goalCopy = goal;
 
     //Continue until all goal stations are visited
-    // while (goal.size() > 0) {
+    // while (goalCopy.size() > 0) {
 
-    //^^^^^^^^^^^ INFINITE LOOP RESULTS BECAUSE LIST OF SUBWAY STATIONS HAS REPEATING IDS.
-        for (int i = 0; i < 10; i++) {
+    //^^^^^^^^^^^ INFINITE LOOP TESTING
+        for (int i = 0; i < 25; i++) {
 
         //Map to store station id and heuristic
         std::map<int,int> nextHeuristics;
@@ -274,6 +274,10 @@ void testAlgHeuristics(std::vector<Station> stations, std::vector<int> goal,
             goalCopy.erase(itr);
         }
 
+        //All goals visited
+        if (goalCopy.size() == 0) {
+            return;
+        }
         //Continue with best choice (min heuristic station)
         //VVVVVVVVVVVVVVVVVVVVVVVVVVVVV
         //BUG: No unvisited stations case - find closest unvisited station
@@ -281,7 +285,6 @@ void testAlgHeuristics(std::vector<Station> stations, std::vector<int> goal,
 
         //Print next station
         std::cout << "->" << currStation;
-
     }
 }
 

--- a/algos.cpp
+++ b/algos.cpp
@@ -137,8 +137,7 @@ std::vector<int> testAlg(std::vector<Station> stations, std::vector<int> goal,
   int start){
     //Minimum cost up to goal from root
     std::vector<int> answer;
-    for (long unsigned int i = 0; i < goal.size(); i++) {
-
+    for (int i = 0; i < goal.size(); i++) {
         answer.push_back(INT_MAX);
     }
     //Queue stores cumulative distance and station id
@@ -146,25 +145,22 @@ std::vector<int> testAlg(std::vector<Station> stations, std::vector<int> goal,
     //map stores station id and bit representing if it was visited
     //0 = unvisited, 1 = visited
     std::map<int,int> visited;
-    for (long unsigned int i = 0; i < stations.size(); i++) {
+    for (int i = 0; i < stations.size(); i++) {
         visited.insert({stations[i].getId(), 0});
     }
 
-    long unsigned int count = 0;
+    int count = 0;
 
     //Insert root into priority queue
     q.push({0, start});
 
-    // //Frontier system to create backpointers
-    // std::vector<Station> frontier;
-    // frontier.push_back(stations[start]);
+    //Frontier system to create backpointers, stores station ids
+    std::vector<int> frontier;
+    frontier.push_back(start);
 
     while (q.size() > 0) {
         //Find top element of the priority queue
         std::pair<int,int> top = q.top();
-
-        //TEST PRINT
-        std::cout << top.second << " ";
 
         //Remove element with the highest priority
         q.pop();
@@ -206,21 +202,28 @@ std::vector<int> testAlg(std::vector<Station> stations, std::vector<int> goal,
 
                 q.push({neighborCost, neighborId});
 
-                // //Track predecessors with frontier
-                // //Not in frontier
-                // if (find(frontier.begin(), frontier.end(), 
-                //   stations[i->getEnd()]) == frontier.end()) {
-                //     frontier.push_back(stations[i->getEnd()]);
-                //     //Update predecessor pointer
-                //     stations[i->getEnd()].predecessor = stations[top.second];
-                // }
-                // //Is in frontier but with higher cost
-                // if (find(frontier.begin(), frontier.end(), 
-                //   stations[i->getEnd()]) != frontier.end()) {
-                //     if () {
-                        
-                //     }
-                // }
+                //Track predecessors with frontier
+                //Not visited
+                if (visited[i->getEnd()] == 0) {
+                    //Not in frontier
+                    if (find(frontier.begin(), frontier.end(), 
+                    i->getEnd()) == frontier.end()) {
+                        frontier.push_back(i->getEnd());
+                        //Update predecessor pointer
+                        //THIS IS RETURNING NULL? WHY vvvvvvvvvvvvv
+                        stations[i->getEnd()].predecessor = &stations[top.second];
+                    }
+                    // //Is in frontier but with higher cost
+                    // if (find(frontier.begin(), frontier.end(), 
+                    // i->getEnd()) != frontier.end()) {
+                    //     //Check if it has a higher cost (not sure if needed)
+                    //     //replace existing node with current neighbor
+                    //     *(find(frontier.begin(), frontier.end(), 
+                    //     i->getEnd())) = i->getEnd();
+                    //     //Set neighbor's predecessor pointer
+                    //     stations[i->getEnd()].predecessor = &stations[top.second];
+                    // }
+                }
             }
 
             //Mark current nodes as visited

--- a/algos.cpp
+++ b/algos.cpp
@@ -12,6 +12,8 @@
 
 using std::size_t;
 
+int heuristic(std::vector<Station> & stations, int currId, int nextId);
+
 // return manhattan distance between two stations
 double manhattanDistance(const Station &s1, const Station &s2){
     double diffX = std::abs( s1.getCords().first - s2.getCords().first );
@@ -236,65 +238,110 @@ std::vector<int> testAlg(std::vector<Station> stations, std::vector<int> goal,
     return answer;
 }
 
+//Heuristics only test algorithm
+void testAlgHeuristics(std::vector<Station> stations, std::vector<int> goal,
+  int start) {
+    int currStation = start;
+    //Print starting station
+    std::cout << start;
+    std::vector<int> goalCopy = goal;
+
+    //Continue until all goal stations are visited
+    // while (goal.size() > 0) {
+
+    //^^^^^^^^^^^ INFINITE LOOP RESULTS BECAUSE LIST OF SUBWAY STATIONS HAS REPEATING IDS.
+        for (int i = 0; i < 10; i++) {
+
+        //Map to store station id and heuristic
+        std::map<int,int> nextHeuristics;
+        //Iterate through possible neighbors
+        std::list<Trip> trips = stations[currStation].getTrips();
+        std::list<Trip>::iterator iterT;
+        for(iterT = trips.begin(); iterT != trips.end(); iterT++){
+            int neighbor = iterT->getEnd();
+
+            //Heuristics helper function
+            nextHeuristics.insert(
+                {heuristic(stations, currStation, neighbor), neighbor}
+            );
+        }
+        
+        //Update visited stations
+        stations[currStation].setVisited(true);
+        //Remove from goal if applicable
+        std::vector<int>::iterator itr = std::find(goalCopy.begin(), goalCopy.end(), currStation);
+        if (itr != goalCopy.end()) {
+            goalCopy.erase(itr);
+        }
+
+        //Continue with best choice (min heuristic station)
+        //VVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+        //BUG: No unvisited stations case - find closest unvisited station
+        currStation = nextHeuristics.begin()->second;
+
+        //Print next station
+        std::cout << "->" << currStation;
+
+    }
+}
+
 // std::vector<Station> BFS(std::vector<Station> stations, int startingID, int goalID){
 
 // }
 
-//PROPAGATION NOT IMPLEMENTED. HELPER FUNCTION NEEDED FOR PROPAGATION. VVVVVVVVV
-//New version of heuristics function (to be used in combination with UCS)
 //Changes heuristic value of current station and all neighboring 
 // connected stations
-void heuristic(std::vector<Station> & stations, int currId) {
-    const int penaltyVal = 1;
-    std::list<Trip> trips = stations[currId].getTrips();
-    std::list<Trip>::iterator iterT;
+// void heuristic(std::vector<Station> & stations, int currId) {
+//     const int penaltyVal = 1;
+//     std::list<Trip> trips = stations[currId].getTrips();
+//     std::list<Trip>::iterator iterT;
 
-    // -> branch stations are hard coded from north-west station clockwise
-    // ONLY CONSIDERING THE LONGEST BRANCHES CURRENTLY
-    int branchStarts[] = {
-        26 //3rd Ave - 138th St
-    };
+//     // -> branch stations are hard coded from north-west station clockwise
+//     // ONLY CONSIDERING THE LONGEST BRANCHES CURRENTLY
+//     int branchStarts[] = {
+//         26 //3rd Ave - 138th St
+//     };
 
-    //Iterate through all neighboring stations
-    for(iterT = trips.begin(); iterT != trips.end(); iterT++){
-        //Penalize neighbors for being already visited
-        if (stations[iterT->getEnd()].isVisited() == true) {
-            stations[iterT->getEnd()].addHeuristic(penaltyVal);
-        }
+//     //Iterate through all neighboring stations
+//     for(iterT = trips.begin(); iterT != trips.end(); iterT++){
+//         //Penalize neighbors for being already visited
+//         if (stations[iterT->getEnd()].isVisited() == true) {
+//             stations[iterT->getEnd()].addHeuristic(penaltyVal);
+//         }
         
-        //Penalize neighbors if they are not in the same line
-        std::list<std::pair<std::string,int>> currLines = stations[currId].getLines();
-        std::list<std::pair<std::string,int>>::iterator iterCurr;
-        std::list<std::pair<std::string,int>> nextLines = stations[iterT->getEnd()].getLines();
-        std::list<std::pair<std::string,int>>::iterator iterNext;
-        bool sameLine;
-        //Loop through all lines for the current station
-        for (iterCurr = currLines.begin(); iterCurr != currLines.end(); iterCurr++) {
-            //Loop through all lines for the neighboring station
-            for (iterNext = nextLines.begin(); iterNext != nextLines.end(); iterNext++) { 
-                //Check if there is a matching line
-                if (iterCurr->first == iterNext->first) {
-                    sameLine = true;
-                    break;
-                }
-            }
-            //Skip checking the rest of the current stations
-            if (sameLine) {
-                break;
-            }
-        }
-        if (!sameLine) {
-            stations[iterT->getEnd()].addHeuristic(penaltyVal);
-        }
+//         //Penalize neighbors if they are not in the same line
+//         std::list<std::pair<std::string,int>> currLines = stations[currId].getLines();
+//         std::list<std::pair<std::string,int>>::iterator iterCurr;
+//         std::list<std::pair<std::string,int>> nextLines = stations[iterT->getEnd()].getLines();
+//         std::list<std::pair<std::string,int>>::iterator iterNext;
+//         bool sameLine;
+//         //Loop through all lines for the current station
+//         for (iterCurr = currLines.begin(); iterCurr != currLines.end(); iterCurr++) {
+//             //Loop through all lines for the neighboring station
+//             for (iterNext = nextLines.begin(); iterNext != nextLines.end(); iterNext++) { 
+//                 //Check if there is a matching line
+//                 if (iterCurr->first == iterNext->first) {
+//                     sameLine = true;
+//                     break;
+//                 }
+//             }
+//             //Skip checking the rest of the current stations
+//             if (sameLine) {
+//                 break;
+//             }
+//         }
+//         if (!sameLine) {
+//             stations[iterT->getEnd()].addHeuristic(penaltyVal);
+//         }
 
-        //Penalize neighbors if entering a dead end branch
-        for (size_t i = 0; i < (sizeof(branchStarts)/sizeof(int)); i++) {
-            if (branchStarts[i] == iterT->getEnd()) {
-                stations[iterT->getEnd()].addHeuristic(penaltyVal);
-            }
-        }
-    }
-}
+//         //Penalize neighbors if entering a dead end branch
+//         for (size_t i = 0; i < (sizeof(branchStarts)/sizeof(int)); i++) {
+//             if (branchStarts[i] == iterT->getEnd()) {
+//                 stations[iterT->getEnd()].addHeuristic(penaltyVal);
+//             }
+//         }
+//     }
+// }
 
 //PREVIOUS VERSION OF HEURISTICS FUNCTION (still used in main)
 // takes current station id and next station id
@@ -345,20 +392,20 @@ int heuristic(std::vector<Station> & stations, int currId, int nextId){
         sum += penaltyVal;
     }
 
-    // penalty for entering a dead end branch vvvvv
-    // merged with penalty for moving away from large masses of connected stations
-    // -> stations are hard coded from north-west station clockwise
-    // ONLY CONSIDERING THE LONGEST BRANCHES CURRENTLY
-    int branchStarts[] = {
-        26 //3rd Ave - 138th St
-    };
+    // // penalty for entering a dead end branch vvvvv
+    // // merged with penalty for moving away from large masses of connected stations
+    // // -> stations are hard coded from north-west station clockwise
+    // // ONLY CONSIDERING THE LONGEST BRANCHES CURRENTLY
+    // int branchStarts[] = {
+    //     26 //3rd Ave - 138th St
+    // };
 
-    //Check if the station is going into a dead end branch
-    for (size_t i = 0; i < (sizeof(branchStarts)/sizeof(int)); i++) {
-        if (branchStarts[i] == nextId) {
-            sum += penaltyVal;
-        }
-    }
+    // //Check if the station is going into a dead end branch
+    // for (size_t i = 0; i < (sizeof(branchStarts)/sizeof(int)); i++) {
+    //     if (branchStarts[i] == nextId) {
+    //         sum += penaltyVal;
+    //     }
+    // }
 
     return sum;
 }

--- a/algos.cpp
+++ b/algos.cpp
@@ -209,9 +209,12 @@ std::vector<int> testAlg(std::vector<Station> stations, std::vector<int> goal,
                     if (find(frontier.begin(), frontier.end(), 
                     i->getEnd()) == frontier.end()) {
                         frontier.push_back(i->getEnd());
-                        //Update predecessor pointer
-                        //THIS IS RETURNING NULL? WHY vvvvvvvvvvvvv
-                        stations[i->getEnd()].predecessor = &stations[top.second];
+                        //Update predecessor pointer on the heap
+                        //Creates memory leak, too bad!
+                        Station* p = new Station();
+                        p->setId(top.second);
+
+                        stations[i->getEnd()].predecessor = p;
                     }
                     // //Is in frontier but with higher cost
                     // if (find(frontier.begin(), frontier.end(), 

--- a/algos.h
+++ b/algos.h
@@ -11,8 +11,7 @@
 double realDistance(const Station& s1, const Station& s2);
 
 int heuristic(std::vector<Station> & stations, int currId, int nextId);
-std::vector<int> testAlg(std::vector<Station> stations, std::vector<int> goal, int start);
-void testAlgHeuristics(std::vector<Station> stations, std::vector<int> goal, int start);
+std::vector<int> testAlg(std::vector<Station> stations, int start);
 
 // Functions for transversal in main
 

--- a/algos.h
+++ b/algos.h
@@ -11,8 +11,8 @@
 double realDistance(const Station& s1, const Station& s2);
 
 int heuristic(std::vector<Station> & stations, int currId, int nextId);
-std::vector<int> testAlg(std::vector<Station> stations, std::vector<int> goal,
-  int start);
+std::vector<int> testAlg(std::vector<Station> stations, std::vector<int> goal, int start);
+void testAlgHeuristics(std::vector<Station> stations, std::vector<int> goal, int start);
 
 // Functions for transversal in main
 

--- a/lineData.txt
+++ b/lineData.txt
@@ -1,764 +1,721 @@
 Line: 1
-station name: Van Cortlandt Park - 242nd St, index: 270
-station name: 238th St, index: 5
-station name: 231st St, index: 266
-station name: Marble Hill - 225th St, index: 265
-station name: 215th St, index: 267
-station name: 207th St, index: 268
-station name: Dyckman St, index: 285
-station name: 191st St, index: 178
-station name: 181st St, index: 177
-station name: 168th St, index: 176
-station name: 157th St, index: 156
-station name: 145th St, index: 155
-station name: 137th St - City College, index: 171
-station name: 125th St, index: 286
-station name: 116th St - Columbia University, index: 166
-station name: Cathedral Pkwy (110th St), index: 165
-station name: 103rd St, index: 158
-station name: 96th St, index: 157
-station name: 86th St, index: 85
-station name: 79th St, index: 192
-station name: 72nd St, index: 161
-station name: 66th St - Lincoln Ctr, index: 87
-station name: 59th St - Columbus Circle, index: 93
-station name: 50th St, index: 2
-station name: Times Sq - 42nd St, index: 358
-station name: 34th St - Penn Station, index: 357
-station name: 28th St, index: 198
-station name: 23rd St, index: 95
-station name: 18th St, index: 202
-station name: 14th St, index: 438
-station name: Christopher St - Sheridan Sq, index: 194
-station name: Houston St, index: 96
-station name: Canal St, index: 89
-station name: Franklin St, index: 463
-station name: Chambers St, index: 403
-station name: WTC Cortlandt, index: 425
-station name: Rector St, index: 424
-station name: South Ferry, index: 417
-station name: South Ferry, index: 417
+station name: Van Cortlandt Park - 242nd St, index: 1
+station name: 238th St, index: 2
+station name: 231st St, index: 3
+station name: Marble Hill - 225th St, index: 4
+station name: 215th St, index: 5
+station name: 207th St, index: 6
+station name: Dyckman St, index: 7 
+station name: 191st St, index: 8
+station name: 181st St, index: 9
+station name: 168th St, index: 10
+station name: 157th St, index: 11
+station name: 145th St, index: 12
+station name: 137th St - City College, index: 13
+station name: 125th St, index: 14
+station name: 116th St - Columbia University, index: 15
+station name: Cathedral Pkwy (110th St), index: 16
+station name: 103rd St, index: 17
+station name: 96th St, index: 18
+station name: 86th St, index: 19
+station name: 79th St, index: 20
+station name: 72nd St, index: 21
+station name: 66th St - Lincoln Ctr, index: 22
+station name: 59th St - Columbus Circle, index: 23
+station name: 50th St, index: 24
+station name: Times Sq - 42nd St, index: 25
+station name: 34th St - Penn Station, index: 26
+station name: 28th St, index: 27
+station name: 23rd St, index: 28
+station name: 18th St, index: 29
+station name: 14th St, index: 30
+station name: Christopher St - Sheridan Sq, index: 31
+station name: Houston St, index: 32
+station name: Canal St, index: 33
+station name: Franklin St, index: 34
+station name: Chambers St, index: 35
+station name: WTC Cortlandt, index: 36
+station name: Rector St, index: 37
+station name: South Ferry, index: 38
 
 Line: 2
-station name: Wakefield - 241st St, index: 279
-station name: 233rd St, index: 86
-station name: 225th St, index: 247
-station name: 219th St, index: 272
-station name: Gun Hill Rd, index: 39
-station name: Burke Ave, index: 275
-station name: Allerton Ave, index: 256
-station name: Pelham Pkwy, index: 38
-station name: Bronx Park E, index: 43
-station name: E 180th St, index: 284
-station name: W Farms Sq - E Tremont Ave, index: 271
-station name: 174th St, index: 255
-station name: Freeman St, index: 17
-station name: Simpson St, index: 42
-station name: Intervale Ave, index: 18
-station name: Prospect Ave, index: 253
-station name: Jackson Ave, index: 252
-station name: 3rd Ave - 149th St, index: 289
-station name: 149th St - Grand Concourse, index: 288
-station name: 135th St, index: 168
-station name: 125th St, index: 167
-station name: 116th St, index: 169
-station name: Central Park North (110th St), index: 159
-station name: 96th St, index: 157
-station name: 86th St, index: 85
-station name: 79th St, index: 192
-station name: 72nd St, index: 161
-station name: 66th St - Lincoln Ctr, index: 87
-station name: 59th St - Columbus Circle, index: 93
-station name: 50th St, index: 2
-station name: Times Sq - 42nd St, index: 358
-station name: 34th St - Penn Station, index: 357
-station name: 28th St, index: 198
-station name: 23rd St, index: 95
-station name: 18th St, index: 202
-station name: 14th St, index: 438
-station name: Christopher St - Sheridan Sq, index: 194
-station name: Houston St, index: 96
-station name: Canal St, index: 89
-station name: Franklin St, index: 463
-station name: Chambers St, index: 403
-station name: Park Pl, index: 402
-station name: Fulton St, index: 401
-station name: Wall St, index: 429
-station name: Clark St, index: 445
-station name: Borough Hall, index: 405
-station name: Hoyt St, index: 404
-station name: Nevins St, index: 127
-station name: Atlantic Ave - Barclays Ctr, index: 115
-station name: Bergen St, index: 3
-station name: Grand Army Plaza, index: 114
-station name: Eern Pkwy - Brooklyn Museum, index: 128
-station name: Franklin Ave, index: 41
-station name: President St, index: 454
-station name: Sterling St, index: 133
-station name: Winthrop St, index: 44
-station name: Church Ave, index: 130
-station name: Beverly Rd, index: 129
-station name: Newkirk Ave, index: 131
+station name: Wakefield - 241st St, index: 39
+station name: Nereid Av, index: 40
+station name: 233rd St, index: 41
+station name: 225th St, index: 42
+station name: 219th St, index: 43
+station name: Gun Hill Rd, index: 44
+station name: Burke Ave, index: 45
+station name: Allerton Ave, index: 46
+station name: Pelham Pkwy, index: 47
+station name: Bronx Park E, index: 48
+station name: E 180th St, index: 49
+station name: W Farms Sq - E Tremont Ave, index: 50
+station name: 174th St, index: 51
+station name: Freeman St, index: 52
+station name: Simpson St, index: 53
+station name: Intervale Ave, index: 54
+station name: Prospect Ave, index: 55
+station name: Jackson Ave, index: 56
+station name: 3rd Ave - 149th St, index: 57 
+station name: 149th St - Grand Concourse, index: 58
+station name: 135th St, index: 59
+station name: 125th St, index: 60
+station name: 116th St, index: 61
+station name: Central Park North (110th St), index: 62
+station name: 96th St, index: 18
+station name: 72nd St, index: 21
+station name: Times Sq - 42nd St, index: 25
+station name: 34th St - Penn Station, index: 26
+station name: 14th St, index: 30
+station name: Chambers St, index: 35
+station name: Park Pl, index: 63
+station name: Fulton St, index: 64
+station name: Wall St, index: 65
+station name: Clark St, index: 66
+station name: Borough Hall, index: 67
+station name: Hoyt St, index: 68
+station name: Nevins St, index: 69
+station name: Atlantic Ave - Barclays Ctr, index: 70
+station name: Bergen St, index: 71
+station name: Grand Army Plaza, index: 72
+station name: Eern Pkwy - Brooklyn Museum, index: 73
+station name: Franklin Ave, index: 74
+station name: President St, index: 75
+station name: Sterling St, index: 76
+station name: Winthrop St, index: 77
+station name: Church Ave, index: 78
+station name: Beverly Rd, index: 79
+station name: Newkirk Ave, index: 80
+station name: Flatbush Ave, index: 81
 
 Line: 3
-station name: Harlem - 148th St, index: 260
-station name: 145th St, index: 172
-station name: 135th St, index: 168
-station name: 125th St, index: 167
-station name: 116th St, index: 169
-station name: Central Park North (110th St), index: 159
-station name: 96th St, index: 157
-station name: 72nd St, index: 161
-station name: Times Sq - 42nd St, index: 358
-station name: 34th St - Penn Station, index: 357
-station name: 14th St, index: 438
-station name: Chambers St, index: 403
-station name: Park Pl, index: 402
-station name: Fulton St, index: 401
-station name: Wall St, index: 429
-station name: Clark St, index: 445
-station name: Borough Hall, index: 405
-station name: Hoyt St, index: 404
-station name: Nevins St, index: 127
-station name: Atlantic Ave - Barclays Ctr, index: 115
-station name: Bergen St, index: 3
-station name: Grand Army Plaza, index: 114
-station name: Eern Pkwy - Brooklyn Museum, index: 128
-station name: Franklin Ave, index: 41
-station name: Nostrand Ave, index: 444
-station name: Kingston Ave, index: 135
-station name: Crown Heights - Utica Ave, index: 134
-station name: Sutter Ave - Rutland Rd, index: 221
-station name: Saratoga Ave, index: 220
-station name: Rockaway Ave, index: 217
-station name: Junius St, index: 216
-station name: Pennsylvania Ave, index: 4
-station name: Van Siclen Ave, index: 45
-station name: New Lots Ave, index: 212
+station name: Harlem - 148th St, index: 83
+station name: 145th St, index: 84
+station name: 135th St, index: 59
+station name: 125th St, index: 60
+station name: 116th St, index: 61
+station name: Central Park North (110th St), index: 62
+station name: 96th St, index: 18
+station name: 72nd St, index: 21
+station name: Times Sq - 42nd St, index: 25
+station name: 34th St - Penn Station, index: 26
+station name: 14th St, index: 30
+station name: Chambers St, index: 35
+station name: Park Pl, index: 63
+station name: Fulton St, index: 64
+station name: Wall St, index: 65
+station name: Clark St, index: 66
+station name: Borough Hall, index: 67
+station name: Hoyt St, index: 68
+station name: Nevins St, index: 69
+station name: Atlantic Ave - Barclays Ctr, index: 70
+station name: Bergen St, index: 71
+station name: Grand Army Plaza, index: 72
+station name: Eern Pkwy - Brooklyn Museum, index: 73
+station name: Franklin Ave, index: 74
+station name: Nostrand Ave, index: 85
+station name: Kingston Ave, index: 86
+station name: Crown Heights - Utica Ave, index: 87
+station name: Sutter Ave - Rutland Rd, index: 88
+station name: Saratoga Ave, index: 89
+station name: Rockaway Ave, index: 90
+station name: Junius St, index: 91
+station name: Pennsylvania Ave, index: 92
+station name: Van Siclen Ave, index: 93
+station name: New Lots Ave, index: 94
 
 Line: 4
-station name: Woodlawn, index: 455
-station name: Mosholu Pkwy, index: 273
-station name: Bedford Park Boulevard - Lehman College, index: 259
-station name: Kingsbridge Rd, index: 258
-station name: Fordham Rd, index: 407
-station name: 183rd St, index: 406
-station name: Burnside Ave, index: 174
-station name: 176th St, index: 173
-station name: Mount Eden Ave, index: 261
-station name: 170th St, index: 263
-station name: 167th St, index: 290
-station name: 161st St - Yankee Stadium, index: 47
-station name: 149th St - Grand Concourse, index: 46
-station name: 138th St - Grand Concourse, index: 140
-station name: 125th St, index: 467
-station name: 116th St, index: 461
-station name: 110th St, index: 449
-station name: 103rd St, index: 457
-station name: 96th St, index: 32
-station name: 86th St, index: 450
-station name: 77th St, index: 33
-station name: 68th St - Hunter College, index: 101
-station name: 51st St, index: 84
-station name: Grand Central - 42nd St, index: 30
-station name: 33rd St, index: 31
-station name: 28th St, index: 199
-station name: 23rd St, index: 91
-station name: Astor Pl, index: 0
-station name: Bleecker St, index: 456
-station name: Spring St, index: 466
-station name: Canal St, index: 1
-station name: Brooklyn Bridge - City Hall, index: 28
-station name: Fulton St, index: 426
-station name: Wall St, index: 419
-station name: Bowling Green, index: 418
-station name: Borough Hall, index: 122
-station name: Nevins St, index: 127
-station name: Atlantic Ave - Barclays Ctr, index: 115
-station name: Bergen St, index: 3
-station name: Grand Army Plaza, index: 114
-station name: Eern Pkwy - Brooklyn Museum, index: 128
-station name: Franklin Ave, index: 41
-station name: Nostrand Ave, index: 444
-station name: Kingston Ave, index: 135
-station name: Crown Heights - Utica Ave, index: 134
+station name: Woodlawn, index: 95
+station name: Mosholu Pkwy, index: 96
+station name: Bedford Park Boulevard - Lehman College, index: 97
+station name: Kingsbridge Rd, index: 98
+station name: Fordham Rd, index: 99
+station name: 183rd St, index: 100
+station name: Burnside Ave, index: 101
+station name: 176th St, index: 102
+station name: Mount Eden Ave, index: 103
+station name: 170th St, index: 104
+station name: 167th St, index: 105
+station name: 161st St - Yankee Stadium, index: 106
+station name: 149th St - Grand Concourse, index: 58
+station name: 138th St - Grand Concourse, index: 107
+station name: 125th St, index: 108
+station name: 86th St, index: 109
+station name: 59th St, index: 110
+station name: Grand Central - 42nd St, index: 110
+station name: 14th St - Union Sq, index: 111
+station name: Brooklyn Bridge - City Hall, index: 112
+station name: Fulton St, index: 64
+station name: Wall St, index: 113
+station name: Bowling Green, index: 114
+station name: Borough Hall, index: 67
+station name: Nevins St, index: 69
+station name: Atlantic Ave - Barclays Ctr, index: 70
+station name: Franklin Ave, index: 74
+station name: Crown Heights - Utica Ave, index: 87
 
 Line: 5
-station name: 233rd St, index: 86
-station name: 225th St, index: 247
-station name: 219th St, index: 272
-station name: Gun Hill Rd, index: 39
-station name: Burke Ave, index: 275
-station name: Allerton Ave, index: 256
-station name: Pelham Pkwy, index: 38
-station name: Bronx Park E, index: 43
-station name: Echester - Dyre Ave, index: 277
-station name: Baychester Ave, index: 276
-station name: Gun Hill Rd, index: 39
-station name: Pelham Pkwy, index: 38
-station name: Morris Park, index: 124
-station name: E 180th St, index: 284
-station name: W Farms Sq - E Tremont Ave, index: 271
-station name: 174th St, index: 255
-station name: Freeman St, index: 17
-station name: Simpson St, index: 42
-station name: Intervale Ave, index: 18
-station name: Prospect Ave, index: 253
-station name: Jackson Ave, index: 252
-station name: 3rd Ave - 149th St, index: 289
-station name: 149th St - Grand Concourse, index: 288
-station name: 138th St - Grand Concourse, index: 140
-station name: 125th St, index: 467
-station name: 86th St, index: 450
-station name: Grand Central - 42nd St, index: 30
-station name: Brooklyn Bridge - City Hall, index: 28
-station name: Fulton St, index: 426
-station name: Wall St, index: 419
-station name: Bowling Green, index: 418
-station name: Borough Hall, index: 122
-station name: Nevins St, index: 127
-station name: Atlantic Ave - Barclays Ctr, index: 115
-station name: Franklin Ave, index: 41
-station name: President St, index: 454
-station name: Sterling St, index: 133
-station name: Winthrop St, index: 44
-station name: Church Ave, index: 130
-station name: Beverly Rd, index: 129
-station name: Newkirk Ave, index: 131
+station name: Echester - Dyre Ave, index: 115
+station name: Baychester Ave, index: 116
+station name: Gun Hill Rd, index: 117
+station name: Pelham Pkwy, index: 118
+station name: Morris Park, index: 119
+station name: E 180th St, index: 49
+station name: W Farms Sq - E Tremont Ave, index: 50
+station name: 174th St, index: 51
+station name: Freeman St, index: 52
+station name: Simpson St, index: 53
+station name: Intervale Ave, index: 54
+station name: Prospect Ave, index: 55
+station name: Jackson Ave, index: 56
+station name: 3rd Ave - 149th St, index: 57
+station name: 149th St - Grand Concourse, index: 58
+station name: 138th St - Grand Concourse, index: 107
+station name: 125th St, index: 108
+station name: 86th St, index: 109
+station name: 59th St, index: 110
+station name: Grand Central - 42nd St, index: 110
+station name: 14th St - Union Sq, index: 111
+station name: Brooklyn Bridge - City Hall, index: 112
+station name: Fulton St, index: 64
+station name: Wall St, index: 113
+station name: Bowling Green, index: 114
+station name: Borough Hall, index: 67
+station name: Nevins St, index: 69
+station name: Atlantic Ave - Barclays Ctr, index: 70
+station name: Franklin Ave, index: 74
+station name: President St, index: 75
+station name: Sterling St, index: 76
+station name: Winthrop St, index: 77
+station name: Church Ave, index: 78
+station name: Beverly Rd, index: 79
+station name: Newkirk Ave, index: 80
+station name: Flatbush Ave, index: 81
 
 Line: 6
-station name: Buhre Ave, index: 25
-station name: Middletown Rd, index: 90
-station name: Wchester Sq - E Tremont Ave, index: 201
-station name: Zerega Ave, index: 29
-station name: Castle Hill Ave, index: 27
-station name: Parkchester, index: 462
-station name: St. Lawrence Ave, index: 52
-station name: Morrison Ave - Soundview, index: 50
-station name: Elder Ave, index: 248
-station name: Whitlock Ave, index: 51
-station name: Hunts Point Ave, index: 88
-station name: Longwood Ave, index: 249
-station name: E 149th St, index: 49
-station name: E 143rd St - St. Mary's St, index: 257
-station name: Cypress Ave, index: 254
-station name: Brook Ave, index: 291
-station name: 3rd Ave - 138th St, index: 26
-station name: 125th St, index: 467
-station name: 116th St, index: 461
-station name: 110th St, index: 449
-station name: 103rd St, index: 457
-station name: 96th St, index: 32
-station name: 86th St, index: 450
-station name: 77th St, index: 33
-station name: 68th St - Hunter College, index: 101
-station name: 51st St, index: 84
-station name: Grand Central - 42nd St, index: 30
-station name: 33rd St, index: 31
-station name: 28th St, index: 199
-station name: 23rd St, index: 91
-station name: Astor Pl, index: 0
-station name: Bleecker St, index: 456
-station name: Spring St, index: 466
-station name: Canal St, index: 1
-station name: Brooklyn Bridge - City Hall, index: 28
+station name: Pelham Bay Park, index: 120
+station name: Buhre Ave, index: 121
+station name: Middletown Rd, index: 123
+station name: Westchester Sq - E Tremont Ave, index: 124
+station name: Zerega Ave, index: 125
+station name: Castle Hill Ave, index: 126
+station name: Parkchester, index: 127
+station name: St. Lawrence Ave, index: 128
+station name: Morrison Ave - Soundview, index: 129
+station name: Elder Ave, index: 130
+station name: Whitlock Ave, index: 131
+station name: Hunts Point Ave, index: 132
+station name: Longwood Ave, index: 133
+station name: E 149th St, index: 134
+station name: E 143rd St - St. Mary's St, index: 135
+station name: Cypress Ave, index: 136
+station name: Brook Ave, index: 137
+station name: 3rd Ave - 138th St, index: 138
+station name: 125th St, index: 108
+station name: 116th St, index: 139
+station name: 110th St, index: 140
+station name: 103rd St, index: 141
+station name: 96th St, index: 142
+station name: 86th St, index: 109
+station name: 77th St, index: 143
+station name: 68th St - Hunter College, index: 144
+station name: 59th St, index: 110
+station name: 51st St - Lexington Ave - 53rd St, index: 145
+station name: Grand Central - 42nd St, index: 110
+station name: 33rd St, index: 146
+station name: 28th St, index: 147
+station name: 23rd St, index: 148
+station name: 14th St - Union Sq, index: 111
+station name: Astor Pl, index: 149
+station name: Bleecker St, index: 150
+station name: Spring St, index: 151
+station name: Canal St, index: 152
+station name: Brooklyn Bridge - City Hall, index: 112
 
 Line: 7
-station name: Mets - Willets Point, index: 22
-station name: 111th St, index: 189
-station name: 103rd St - Corona Plaza, index: 188
-station name: Junction Boulevard, index: 23
-station name: 90th St - Elmhurst Ave, index: 240
-station name: 82nd St - Jackson Heights, index: 239
-station name: 74th St - Broadway, index: 230
-station name: 69th St, index: 229
-station name: 52nd St, index: 235
-station name: 33rd St - Rawson St, index: 239
-station name: Queensboro Plaza, index: 102
-station name: Court Sq, index: 92
-station name: Hunters Point Ave, index: 94
-station name: Vernon Boulevard - Jackson Ave, index: 100
-station name: Grand Central, index: 203
-station name: Times Sq, index: 196
-station name: 34th St - Hudson Yards, index: 469
-station name: 14th St - Hudson Terminal, index: 469
+station name: Flushing - Main St, index: 153
+station name: Mets - Willets Point, index: 154
+station name: 111th St, index: 155
+station name: 103rd St - Corona Plaza, index: 156
+station name: Junction Boulevard, index: 157
+station name: 90th St - Elmhurst Ave, index: 158
+station name: 82nd St - Jackson Heights, index: 159
+station name: Jackson Heights - Roosevelt Ave, index: 160
+station name: 69th St, index: 161
+station name: 61st St - Woodside, index: 162
+station name: 52nd St, index: 163
+station name: 46th St - Bliss St, index: 164
+station name: 40th St - Lowery St, index: 165
+station name: 33rd St - Rawson St, index: 166
+station name: Queensboro Plaza, index: 167
+station name: Court Sq, index: 168
+station name: Hunters Point Ave, index: 169
+station name: Vernon Boulevard - Jackson Ave, index: 170
+station name: Grand Central - 42nd St, index: 110
+station name: Times Sq - 42nd St, index: 25
+station name: 34th St - Hudson Yards, index: 171
 
 Line: A
-station name: Inwood - 207th St, index: 269
-station name: Dyckman St, index: 430
-station name: 190th St, index: 396
-station name: 181st St, index: 395
-station name: 175th St, index: 179
-station name: 168th St, index: 57
-station name: 163rd St - Amsterdam Ave, index: 411
-station name: 155th St, index: 410
-station name: 145th St, index: 294
-station name: 135th St, index: 439
-station name: 125th St, index: 398
-station name: 116th St, index: 397
-station name: Cathedral Pkwy (110th St), index: 6
-station name: 103rd St, index: 160
-station name: 96th St, index: 56
-station name: 86th St, index: 164
-station name: 72nd St, index: 55
-station name: 59th St - Columbus Circle, index: 352
-station name: 50th St, index: 346
-station name: 42nd St-Port Authority Bus Terminal, index: 361
-station name: 34th St - Penn Station, index: 436
-station name: 23rd St, index: 435
-station name: 14th St, index: 443
-station name: W Fourth St - Washington Sq, index: 205
-station name: Spring St, index: 394
-station name: Chambers St, index: 360
-station name: Fulton St, index: 359
-station name: High St, index: 452
-station name: Jay St - MetroTech, index: 367
-station name: Hoyt - Schermerhorn Sts, index: 366
-station name: Lafayette Ave, index: 453
-station name: Clinton - Washington Aves, index: 447
-station name: Franklin Ave, index: 446
-station name: Nostrand Ave, index: 126
-station name: Kingston - Throop Aves, index: 7
-station name: Utica Ave, index: 297
-station name: Ralph Ave, index: 37
-station name: Rockaway Ave, index: 116
-station name: Broadway Junction, index: 385
-station name: Liberty Ave, index: 384
-station name: Van Siclen Ave, index: 213
-station name: Shepherd Ave, index: 225
-station name: Euclid Ave, index: 458
-station name: Grant Ave, index: 191
-station name: 80th St, index: 464
-station name: 88th St, index: 459
-station name: Rockaway Boulevard, index: 103
-station name: 104th St, index: 97
-station name: 111th St, index: 82
-station name: Ozone Park - Lefferts Boulevard, index: 195
-station name: Aqueduct Racetrack, index: 123
-station name: Aqueduct - North Conduit Ave, index: 242
-station name: Howard Beach - JFK Airport, index: 241
-station name: Broad Channel, index: 98
-station name: Beach 67th St, index: 204
-station name: Beach 60th St, index: 181
-station name: Beach 44th St, index: 180
-station name: Beach 36th St, index: 184
-station name: Beach 25th St, index: 185
-station name: Far Rockaway - Mott Ave, index: 54
-station name: Beach 90th St, index: 16
-station name: Beach 98th St, index: 182
-station name: Beach 105th St, index: 15
-station name: Rockaway Park - Beach 116th St, index: 183
+station name: Inwood - 207th St, index: 172
+station name: Dyckman St, index: 173
+station name: 190th St, index: 174
+station name: 181st St, index: 175
+station name: 175th St, index: 176
+station name: 168th St, index: 10
+station name: 145th St, index: 177
+station name: 125th St, index: 178
+station name: 59th St - Columbus Circle, index: 23
+station name: 42nd St-Port Authority Bus Terminal, index: 179
+station name: 34th St - Penn Station, index: 180
+station name: 14th St, index: 181
+station name: W Fourth St - Washington Sq, index: 182
+station name: Canal St, index: 183
+station name: Chambers St, index: 184
+station name: Fulton St, index: 64
+station name: High St, index: 185
+station name: Jay St - MetroTech, index: 186
+station name: Hoyt - Schermerhorn Sts, index: 187
+station name: Nostrand Ave, index: 188
+station name: Utica Ave, index: 189
+station name: Broadway Junction, index: 190
+station name: Euclid Ave, index: 191
+station name: Grant Ave, index: 192
+station name: 80th St, index: 193
+station name: 88th St, index: 194
+station name: Rockaway Boulevard, index: 195
+station name: 104th St, index: 196
+station name: 111th St, index: 197
+station name: Ozone Park - Lefferts Boulevard, index: 198
+station name: Aqueduct Racetrack, index: 199
+station name: Aqueduct - North Conduit Ave, index: 200
+station name: Howard Beach - JFK Airport, index: 201
+station name: Broad Channel, index: 202
+station name: Beach 67th St, index: 203
+station name: Beach 60th St, index: 204
+station name: Beach 44th St, index: 205
+station name: Beach 36th St, index: 206
+station name: Beach 25th St, index: 207
+station name: Far Rockaway - Mott Ave, index: 208
+station name: Beach 90th St, index: 209
+station name: Beach 98th St, index: 210
+station name: Beach 105th St, index: 211
+station name: Rockaway Park - Beach 116th St, index: 212
 
 Line: B
-station name: Bedford Park Boulevard, index: 264
-station name: Kingsbridge Rd, index: 58
-station name: Fordham Rd, index: 262
-station name: 182nd - 183rd Sts, index: 19
-station name: Tremont Ave, index: 170
-station name: 174th - 175th Sts, index: 20
-station name: 170th St, index: 175
-station name: 167th St, index: 21
-station name: 161st St - Yankee Stadium, index: 296
-station name: 155th St, index: 295
-station name: 145th St, index: 294
-station name: 135th St, index: 439
-station name: 125th St, index: 398
-station name: 116th St, index: 397
-station name: Cathedral Pkwy (110th St), index: 6
-station name: 103rd St, index: 160
-station name: 96th St, index: 56
-station name: 86th St, index: 164
-station name: 72nd St, index: 55
-station name: 59th St - Columbus Circle, index: 352
-station name: 47th - 50th Sts - Rockefeller Ctr, index: 348
-station name: 42nd St - Bryant Park, index: 59
-station name: Broadway - Lafayette St, index: 432
-station name: Grand St, index: 431
-station name: DeKalb Ave, index: 14
-station name: Atlantic Ave - Barclays Ctr, index: 120
-station name: Prospect Park, index: 60
-station name: Church Ave, index: 111
-station name: Newkirk Ave, index: 112
-station name: Kings Highway, index: 329
-station name: Sheepshead Bay, index: 327
-station name: Brighton Beach, index: 326
+station name: Bedford Park Boulevard, index: 213
+station name: Kingsbridge Rd, index: 214
+station name: Fordham Rd, index: 215
+station name: 182nd - 183rd Sts, index: 216
+station name: Tremont Ave, index: 217
+station name: 174th - 175th Sts, index: 218
+station name: 170th St, index: 219
+station name: 167th St, index: 220
+station name: 161st St - Yankee Stadium, index: 106
+station name: 155th St, index: 221
+station name: 145th St, index: 177
+station name: 135th St, index: 222
+station name: 125th St, index: 178
+station name: 116th St, index: 223
+station name: Cathedral Pkwy (110th St), index: 224
+station name: 103rd St, index: 225
+station name: 96th St, index: 226
+station name: 86th St, index: 227
+station name: 81th St - Museum of Natural History, index: 228
+station name: 72nd St, index: 229
+station name: 59th St - Columbus Circle, index: 23
+station name: 7th Ave, index: 230
+station name: 47th - 50th Sts - Rockefeller Ctr, index: 231
+station name: 42nd St - Bryant Park, index: 232
+station name: 34th St - Herald Sq, index: 233
+station name: W Fourth St Wash Sq, index: 182
+station name: Broadway - Lafayette St, index: 244
+station name: Grand St, index: 245
+station name: DeKalb Ave, index: 246
+station name: Atlantic Ave - Barclays Ctr, index: 70
+station name: 7 Ave, index: 247
+station name: Prospect Park, index: 248
+station name: Church Ave, index: 249
+station name: Newkirk Plaza, index: 250
+station name: Kings Highway, index: 251
+station name: Sheepshead Bay, index: 252
+station name: Brighton Beach, index: 253
 
 Line: C
-station name: 168th St, index: 57
-station name: 163rd St - Amsterdam Ave, index: 411
-station name: 155th St, index: 410
-station name: 145th St, index: 294
-station name: 135th St, index: 439
-station name: 125th St, index: 398
-station name: 116th St, index: 397
-station name: Cathedral Pkwy (110th St), index: 6
-station name: 103rd St, index: 160
-station name: 96th St, index: 56
-station name: 86th St, index: 164
-station name: 72nd St, index: 55
-station name: 59th St - Columbus Circle, index: 352
-station name: 50th St, index: 346
-station name: 42nd St-Port Authority Bus Terminal, index: 361
-station name: 34th St - Penn Station, index: 436
-station name: 23rd St, index: 435
-station name: 14th St, index: 443
-station name: W Fourth St - Washington Sq, index: 205
-station name: Spring St, index: 394
-station name: Chambers St, index: 360
-station name: Fulton St, index: 359
-station name: High St, index: 452
-station name: Jay St - MetroTech, index: 367
-station name: Hoyt - Schermerhorn Sts, index: 366
-station name: Lafayette Ave, index: 453
-station name: Clinton - Washington Aves, index: 447
-station name: Franklin Ave, index: 446
-station name: Nostrand Ave, index: 126
-station name: Kingston - Throop Aves, index: 7
-station name: Utica Ave, index: 297
-station name: Ralph Ave, index: 37
-station name: Rockaway Ave, index: 116
-station name: Broadway Junction, index: 385
-station name: Liberty Ave, index: 384
-station name: Van Siclen Ave, index: 213
-station name: Shepherd Ave, index: 225
-station name: Euclid Ave, index: 458
+station name: 168th St, index: 10
+station name: 163rd St - Amsterdam Ave, index: 254
+station name: 155th St, index: 255
+station name: 145th St, index: 177
+station name: 135th St, index: 222
+station name: 125th St, index: 178
+station name: 116th St, index: 223
+station name: Cathedral Pkwy (110th St), index: 224
+station name: 103rd St, index: 225
+station name: 96th St, index: 226
+station name: 86th St, index: 227
+station name: 81st St - Museum of Natural History, index: 228
+station name: 72nd St, index: 229
+station name: 59th St - Columbus Circle, index: 23
+station name: 50th St, index: 256
+station name: 42nd St-Port Authority Bus Terminal, index: 179
+station name: 34th St - Penn Station, index: 180
+station name: 23rd St, index: 257
+station name: 14th St, index: 181
+station name: W Fourth St - Washington Sq, index: 182
+station name: Spring St, index: 258
+station name: Canal St, index: 183
+station name: Chambers St, index: 184
+station name: Fulton St, index: 64
+station name: High St, index: 185
+station name: Jay St - MetroTech, index: 186
+station name: Hoyt - Schermerhorn Sts, index: 187
+station name: Lafayette Ave, index: 259
+station name: Clinton - Washington Aves, index: 260
+station name: Franklin Ave, index: 270
+station name: Nostrand Ave, index: 188
+station name: Kingston - Throop Aves, index: 271
+station name: Utica Ave, index: 189
+station name: Ralph Ave, index: 272
+station name: Rockaway Ave, index: 273
+station name: Broadway Junction, index: 190
+station name: Liberty Ave, index: 274
+station name: Van Siclen Ave, index: 275
+station name: Shepherd Ave, index: 276
+station name: Euclid Ave, index: 191
 
 Line: D
-station name: Norwood - 205th St, index: 274
-station name: Bedford Park Boulevard, index: 264
-station name: Kingsbridge Rd, index: 58
-station name: Fordham Rd, index: 262
-station name: 182nd - 183rd Sts, index: 19
-station name: Tremont Ave, index: 170
-station name: 174th - 175th Sts, index: 20
-station name: 170th St, index: 175
-station name: 167th St, index: 21
-station name: 161st St - Yankee Stadium, index: 296
-station name: 155th St, index: 295
-station name: 145th St, index: 294
-station name: 125th St, index: 398
-station name: 59th St - Columbus Circle, index: 352
-station name: 47th - 50th Sts - Rockefeller Ctr, index: 348
-station name: 42nd St - Bryant Park, index: 59
-station name: Broadway - Lafayette St, index: 432
-station name: Grand St, index: 431
-station name: DeKalb Ave, index: 14
-station name: Atlantic Ave - Barclays Ctr, index: 121
-station name: Union St, index: 35
-station name: Prospect Ave, index: 380
-station name: 25th St, index: 392
-station name: 36th St, index: 388
-station name: Ninth Ave, index: 389
-station name: Fort Hamilton Pkwy, index: 391
-station name: 50th St, index: 310
-station name: 55th St, index: 61
-station name: 62nd St, index: 322
-station name: 71st St, index: 319
-station name: 79th St, index: 318
-station name: 18th Ave, index: 321
-station name: 20th Ave, index: 320
-station name: Bay Pkwy, index: 313
-station name: 25th Ave, index: 312
-station name: Bay 50th St, index: 334
-station name: Coney Island - Stillwell Ave, index: 468
+station name: Norwood - 205th St, index: 277
+station name: Bedford Park Boulevard, index: 213
+station name: Kingsbridge Rd, index: 214
+station name: Fordham Rd, index: 215
+station name: 182nd - 183rd Sts, index: 216
+station name: Tremont Ave, index: 217
+station name: 174th - 175th Sts, index: 218
+station name: 170th St, index: 219
+station name: 167th St, index: 220
+station name: 161st St - Yankee Stadium, index: 106
+station name: 155th St, index: 221
+station name: 145th St, index: 177
+station name: 125th St, index: 178
+station name: 59th St - Columbus Circle, index: 23
+station name: 7 Ave, index: 230
+station name: 47th - 50th Sts - Rockefeller Ctr, index: 231
+station name: 42nd St - Bryant Park, index: 232
+station name: 34th St - Herald Sq, index: 233
+station name: W Fourth St - Wash Sq, index: 182
+station name: Broadway - Lafayette St, index: 244
+station name: Grand St, index: 245
+station name: Atlantic Ave - Barclays Ctr, index: 70
+station name: 36th St, index: 278
+station name: 9 Ave, index: 279
+station name: Fort Hamilton Pkwy, index: 280
+station name: 50th St, index: 281
+station name: 55th St, index: 282
+station name: 62nd St - New Utrecht Ave, index: 283
+station name: 71st St, index: 284
+station name: 79th St, index: 285
+station name: 18th Ave, index: 286
+station name: 20th Ave, index: 287
+station name: Bay Pkwy, index: 288
+station name: 25th Ave, index: 289
+station name: Bay 50th St, index: 290
+station name: Coney Island - Stillwell Ave, index: 291
 
 Line: E
-station name: Jamaica Ctr - Parsons / Archer, index: 246
-station name: Sutphin Boulevard - Archer Ave - JFK Airport, index: 64
-station name: Jamaica - Van Wyck, index: 62
-station name: Briarwood - Van Wyck Boulevard, index: 243
-station name: Kew Gardens - Union Turnpike, index: 63
-station name: 75th Ave, index: 163
-station name: Forest Hills - 71st Ave, index: 244
-station name: 67th Ave, index: 66
-station name: 63rd Drive - Rego Park, index: 190
-station name: Grand Ave - Newtown, index: 67
-station name: Elmhurst Ave, index: 36
-station name: Jackson Heights - Roosevelt Ave, index: 437
-station name: 65th St, index: 8
-station name: Northern Boulevard, index: 237
-station name: 46th St, index: 236
-station name: Steinway St, index: 298
-station name: 36th St, index: 9
-station name: Queens Plaza, index: 306
-station name: Court Sq - 23rd St, index: 65
-station name: Lexington Ave - 53rd St, index: 142
-station name: Fifth Ave / 53rd St , index: 141
-station name: 50th St, index: 346
-station name: 42nd St - Port Authority Bus Terminal, index: 361
-station name: 34th St - Penn Station, index: 436
-station name: 23rd St, index: 435
-station name: 14th St, index: 443
-station name: W Fourth St - Washington Sq, index: 205
-station name: Spring St, index: 394
-station name: World Trade Ctr, index: 408
+station name: Jamaica Ctr - Parsons / Archer, index: 292
+station name: Sutphin Boulevard - Archer Ave - JFK Airport, index: 293
+station name: Jamaica - Van Wyck, index: 294
+station name: Briarwood, index: 295
+station name: Kew Gardens - Union Turnpike, index: 296
+station name: 75th Ave, index: 297
+station name: Forest Hills - 71st Ave, index: 298
+station name: Jackson Heights - Roosevelt Ave, index: 160
+station name: Queens Plaza, index: 299
+station name: Court Sq - 23rd St, index: 168
+station name: 51st St - Lexington Ave - 53rd St, index: 145
+station name: Fifth Ave / 53rd St , index: 300
+station name: 7 Ave, index: 230
+station name: 50th St, index: 256
+station name: 42nd St - Port Authority Bus Terminal, index: 179
+station name: 34th St - Penn Station, index: 180
+station name: 23rd St, index: 257
+station name: 14th St, index: 181
+station name: W Fourth St - Washington Sq, index: 182
+station name: Spring St, index: 258
+station name: Canal St, index: 183
+station name: World Trade Ctr, index: 301
 
 Line: F
-station name: Jamaica - 179th St, index: 278
-station name: 169th St, index: 187
-station name: Parsons Boulevard, index: 186
-station name: Sutphin Boulevard, index: 245
-station name: Briarwood - Van Wyck Boulevard, index: 243
-station name: Kew Gardens - Union Turnpike, index: 63
-station name: 75th Ave, index: 163
-station name: Forest Hills - 71st Ave, index: 244
-station name: Jackson Heights - Roosevelt Ave, index: 437
-station name: 21st St - Queensbridge, index: 345
-station name: Roosevelt Island, index: 351
-station name: Lexington Ave - 63rd St, index: 350
-station name: 47th - 50th Sts - Rockefeller Ctr, index: 348
-station name: 42nd St - Bryant Park, index: 59
-station name: 23rd St, index: 364
-station name: 14th St, index: 440
-station name: Broadway - Lafayette St, index: 432
-station name: York St, index: 451
-station name: Jay St - MetroTech, index: 367
-station name: Bergen St, index: 375
-station name: Carroll St, index: 393
-station name: Smith - Ninth Sts, index: 374
-station name: 15th St - Prospect Park, index: 106
-station name: Fort Hamilton Pkwy, index: 108
-station name: Church Ave, index: 109
-station name: Ditmas Ave, index: 68
-station name: 18th Ave, index: 307
-station name: Ave I, index: 341
-station name: Bay Pkwy, index: 338
-station name: Ave N, index: 337
-station name: Ave P, index: 336
-station name: Kings Highway, index: 325
-station name: Ave U, index: 324
-station name: Ave X, index: 333
+station name: Jamaica - 179th St, index: 302
+station name: 169th St, index: 303
+station name: Parsons Boulevard, index: 304
+station name: Sutphin Boulevard, index: 305
+station name: Briarwood, index: 295
+station name: Kew Gardens - Union Turnpike, index: 296
+station name: 75th Ave, index: 297
+station name: Forest Hills - 71st Ave, index: 298
+station name: Jackson Heights - Roosevelt Ave, index: 160
+station name: 21st St - Queensbridge, index: 306
+station name: Roosevelt Island, index: 307
+station name: 59th St - Lexington Ave - 63rd St, index: 110
+station name: 57th St, index: 308
+station name: 47th - 50th Sts - Rockefeller Ctr, index: 231
+station name: 42nd St - Bryant Park, index: 232
+station name: 34th St - Herald Sq, index: 233
+station name: 23rd St, index: 309
+station name: 14th St, index: 310
+station name: W Fourth St - Wash Sq, index: 182
+station name: Broadway - Lafayette St, index: 244
+station name: 2 Av, index: 311
+station name: Delancey St - Essex St, index: 312
+station name: East Broadway, index: 313
+station name: York St, index: 314
+station name: Jay St - MetroTech, index: 186
+station name: Bergen St, index: 315
+station name: Carroll St, index: 316
+station name: Smith - Ninth Sts, index: 317
+station name: 4th Ave - Ninth St, index: 318
+station name: 7 Ave, index: 319
+station name: 15th St - Prospect Park, index: 320
+station name: Fort Hamilton Pkwy, index: 321
+station name: Church Ave, index: 322
+station name: Ditmas Ave, index: 323
+station name: 18th Ave, index: 324
+station name: Ave I, index: 325
+station name: Bay Pkwy, index: 326
+station name: Ave N, index: 327
+station name: Ave P, index: 328
+station name: Kings Highway, index: 329
+station name: Ave U, index: 330
+station name: Ave X, index: 331
 station name: Neptune Ave, index: 332
-station name: W Eighth St - New York Aquarium, index: 197
-station name: Coney Island - Stillwell Ave, index: 468
+station name: W Eighth St - New York Aquarium, index: 333
+station name: Coney Island - Stillwell Ave, index: 291
 
 Line: G
-station name: 21st St, index: 153
-station name: Greenpoint Ave, index: 137
-station name: Nassau Ave, index: 136
-station name: Metropolitan Ave, index: 147
-station name: Broadway, index: 70
-station name: Flushing Ave, index: 363
-station name: Myrtle - Willoughby Aves, index: 362
-station name: Bedford - Nostrand Aves, index: 105
-station name: Classon Ave, index: 69
-station name: Clinton - Washington Aves, index: 118
-station name: Fulton St, index: 117
-station name: Hoyt - Schermerhorn Sts, index: 366
-station name: Bergen St, index: 375
-station name: Carroll St, index: 393
-station name: Smith - Ninth Sts, index: 374
-station name: 15th St - Prospect Park, index: 106
-station name: Fort Hamilton Pkwy, index: 108
-station name: Church Ave, index: 109
+station name: Court Sq, index: 168
+station name: 21st St, index: 334
+station name: Greenpoint Ave, index: 335
+station name: Nassau Ave, index: 336
+station name: Metropolitan Ave - Lorimer St, index: 337
+station name: Broadway, index: 338
+station name: Flushing Ave, index: 339
+station name: Myrtle - Willoughby Aves, index: 340
+station name: Bedford - Nostrand Aves, index: 341
+station name: Classon Ave, index: 342
+station name: Clinton - Washington Aves, index: 343
+station name: Fulton St, index: 344
+station name: Hoyt - Schermerhorn Sts, index: 187
+station name: Bergen St, index: 315
+station name: Carroll St, index: 316
+station name: Smith - Ninth Sts, index: 317
+station name: 4th Ave - Ninth St, index: 318
+station name: 7 Ave, index: 319
+station name: 15th St - Prospect Park, index: 320
+station name: Fort Hamilton Pkwy, index: 321
+station name: Church Ave, index: 322
 
 Line: J
-station name: Sutphin Boulevard - Archer Ave - JFK Airport, index: 64
-station name: 121st St, index: 209
-station name: 111th St, index: 208
-station name: Woodhaven Boulevard, index: 207
-station name: 85th St - Forest Pkwy, index: 206
-station name: 75th St - Elderts Lane, index: 228
-station name: Cypress Hills, index: 227
-station name: Crescent St, index: 226
-station name: Norwood Ave, index: 12
-station name: Cleveland St, index: 214
-station name: Van Siclen Ave, index: 11
-station name: Alabama Ave, index: 224
-station name: Broadway Junction, index: 223
-station name: Chauncey St, index: 34
-station name: Halsey St, index: 74
-station name: Gates Ave, index: 300
-station name: Kosciuszko St, index: 299
-station name: Myrtle Ave, index: 372
-station name: Flushing Ave, index: 371
-station name: Lorimer St, index: 75
-station name: Hewes St, index: 139
-station name: Marcy Ave, index: 138
-station name: Bowery, index: 433
-station name: Canal St, index: 414
-station name: Chambers St, index: 413
-station name: Fulton St, index: 412
-station name: Broad St, index: 427
+station name: Jamaica Ctr - Parsons / Archer, index: 292
+station name: Sutphin Boulevard - Archer Ave - JFK Airport, index: 293
+station name: 121st St, index: 345
+station name: 111th St, index: 346
+station name: 104th St, index: 347
+station name: Woodhaven Boulevard, index: 348
+station name: 85th St - Forest Pkwy, index: 349
+station name: 75th St - Elderts Lane, index: 350
+station name: Cypress Hills, index: 351
+station name: Crescent St, index: 352
+station name: Norwood Ave, index: 353
+station name: Cleveland St, index: 354
+station name: Van Siclen Ave, index: 355
+station name: Alabama Ave, index: 356
+station name: Broadway Junction, index: 190
+station name: Chauncey St, index: 357
+station name: Halsey St, index: 358
+station name: Gates Ave, index: 359
+station name: Kosciuszko St, index: 360
+station name: Myrtle Ave, index: 361
+station name: Flushing Ave, index: 362
+station name: Lorimer St, index: 363
+station name: Hewes St, index: 364
+station name: Marcy Ave, index: 365
+station name: Delancey St - Essex St, index: 312
+station name: Bowery, index: 366
+station name: Canal St, index: 152
+station name: Brooklyn Bridge - Chambers St, index: 112
+station name: Fulton St, index: 64
+station name: Broad St, index: 367
 
 Line: L
-station name: 3rd Ave, index: 382
-station name: Bedford Ave, index: 150
-station name: Lorimer St, index: 71
-station name: Graham Ave, index: 149
-station name: Grand St, index: 148
-station name: Montrose Ave, index: 151
-station name: Morgan Ave, index: 305
-station name: Jefferson St, index: 304
-station name: DeKalb Ave, index: 234
-station name: Myrtle - Wyckoff Aves, index: 211
-station name: Halsey St, index: 210
-station name: Wilson Ave, index: 73
-station name: Bushwick Ave - Aberdeen St, index: 281
-station name: Broadway Junction, index: 282
-station name: Atlantic Ave, index: 193
-station name: Sutter Ave, index: 72
-station name: Livonia Ave, index: 215
-station name: New Lots Ave, index: 222
-station name: E 105th St, index: 219
-station name: Canarsie - Rockaway Pkwy, index: 218
+station name: 14th St - 8 Av, index: 181
+station name: 14th St - 6 Av, index: 30
+station name: 14th St - Union Sq, index: 111
+station name: 3rd Ave, index: 368
+station name: 1st Ave, index: 369
+station name: Bedford Ave, index: 370
+station name: Metropolitan Ave - Lorimer St, index: 337
+station name: Graham Ave, index: 371
+station name: Grand St, index: 372
+station name: Montrose Ave, index: 373
+station name: Morgan Ave, index: 374
+station name: Jefferson St, index: 375
+station name: DeKalb Ave, index: 376
+station name: Myrtle - Wyckoff Aves, index: 378 
+station name: Halsey St, index: 379
+station name: Wilson Ave, index: 380
+station name: Bushwick Ave - Aberdeen St, index: 381
+station name: Broadway Junction, index: 190
+station name: Atlantic Ave, index: 382
+station name: Sutter Ave, index: 383
+station name: Livonia Ave, index: 384
+station name: New Lots Ave, index: 385
+station name: E 105th St, index: 386
+station name: Canarsie - Rockaway Pkwy, index: 387
 
 Line: M
-station name: Forest Hills - 71st Ave, index: 244
-station name: 67th Ave, index: 66
-station name: 63rd Drive - Rego Park, index: 190
-station name: Grand Ave - Newtown, index: 67
-station name: Elmhurst Ave, index: 36
-station name: Jackson Heights - Roosevelt Ave, index: 437
-station name: 65th St, index: 8
-station name: Northern Boulevard, index: 237
-station name: 46th St, index: 236
-station name: Steinway St, index: 298
-station name: 36th St, index: 9
-station name: Queens Plaza, index: 306
-station name: Court Sq - 23rd St, index: 65
-station name: Lexington Ave - 53rd St, index: 142
-station name: Fifth Ave / 53rd St, index: 141
-station name: 47th - 50th Sts - Rockefeller Ctr, index: 348
-station name: 42nd St - Bryant Park, index: 59
-station name: 23rd St, index: 364
-station name: 14th St, index: 440
-station name: Broadway - Lafayette St, index: 432
-station name: Marcy Ave, index: 138
-station name: Hewes St, index: 139
-station name: Lorimer St, index: 75
-station name: Flushing Ave, index: 371
-station name: Myrtle Ave, index: 372
-station name: Central Ave, index: 301
-station name: Knickerbocker Ave, index: 302
-station name: Myrtle - Wyckoff Aves, index: 232
-station name: Seneca Ave, index: 233
-station name: Forest Ave, index: 448
-station name: Fresh Pond Rd, index: 422
-station name: Middle Village - Metropolitan Ave, index: 423
+station name: Forest Hills - 71st Ave, index: 298
+station name: 67th Ave, index: 388
+station name: 63rd Drive - Rego Park, index: 389
+station name: Woodhaven Blvd, index: 390
+station name: Grand Ave - Newtown, index: 391
+station name: Elmhurst Ave, index: 392
+station name: Jackson Heights - Roosevelt Ave, index: 160
+station name: 65th St, index: 393
+station name: Northern Boulevard, index: 394
+station name: 46th St, index: 395
+station name: Steinway St, index: 396
+station name: 36th St, index: 397
+station name: Queens Plaza, index: 299
+station name: Court Sq - 23rd St, index: 168
+station name: 51st St - Lexington Ave - 53rd St, index: 145
+station name: Fifth Ave / 53rd St, index: 300
+station name: 47th - 50th Sts - Rockefeller Ctr, index: 231
+station name: 42nd St - Bryant Park, index: 232
+station name: 34th St - Herald Sq, index: 233
+station name: 23rd St, index: 309
+station name: 14th St, index: 310
+station name: W Fourth St - Wash Sq, index: 182
+station name: Broadway - Lafayette St, index: 244
+station name: Delancey St - Essex St, index: 312
+station name: Marcy Ave, index: 365
+station name: Hewes St, index: 364
+station name: Lorimer St, index: 363
+station name: Flushing Ave, index: 362
+station name: Myrtle Ave, index: 361
+station name: Central Ave, index: 398
+station name: Knickerbocker Ave, index: 399
+station name: Myrtle - Wyckoff Aves, index: 378
+station name: Seneca Ave, index: 400
+station name: Forest Ave, index: 401
+station name: Fresh Pond Rd, index: 402
+station name: Middle Village - Metropolitan Ave, index: 403
 
 Line: N
-station name: Astoria - Ditmars Boulevard, index: 251
-station name: Astoria Boulevard, index: 250
-station name: 30th Ave, index: 303
-station name: Broadway, index: 78
-station name: 36th Ave, index: 77
-station name: 39th Avenu, index: 154
-station name: Queensboro Plaza, index: 102
-station name: Lexington Ave / 59th St, index: 356
-station name: Fifth Ave / 59th St, index: 355
-station name: 49th St, index: 353
-station name: Times Sq - 42nd St, index: 79
-station name: 28th St, index: 143
-station name: 23rd St, index: 379
-station name: Prince St, index: 399
-station name: Canal St, index: 434
-station name: Court St, index: 377
-station name: Jay St - MetroTech, index: 376
-station name: DeKalb Ave, index: 14
-station name: Atlantic Ave - Barclays Ctr, index: 121
-station name: Union St, index: 35
-station name: Prospect Ave, index: 380
-station name: 25th St, index: 392
-station name: 36th St, index: 388
-station name: 45th St, index: 387
-station name: 53rd St, index: 390
-station name: 59th St, index: 386
-station name: Fort Hamilton Pkwy, index: 311
-station name: New Utrecht Ave, index: 323
-station name: 18th Ave, index: 315
-station name: 20th Ave, index: 314
-station name: Bay Pkwy, index: 340
-station name: Kings Highway, index: 331
-station name: Ave U, index: 330
-station name: Coney Island - Stillwell Ave, index: 468
+station name: Astoria - Ditmars Boulevard, index: 404
+station name: Astoria Boulevard, index: 405
+station name: 30th Ave, index: 406
+station name: Broadway, index: 407
+station name: 36th Ave, index: 408
+station name: 39th Ave, index: 409
+station name: Queensboro Plaza, index: 167
+station name: Lexington Ave / 59th St, index: 110
+station name: Fifth Ave / 59th St, index: 410
+station name: 57th St - 7 Ave, index: 411
+station name: 49th St, index: 412
+station name: Times Sq - 42nd St, index: 25
+station name: 34th St - Herald Sq, index: 233
+station name: 14th St - Union Sq, index: 111
+station name: Canal St, index: 152
+station name: Atlantic Ave - Barclays Center, index: 70
+station name: 36th St, index: 278
+station name: 59th St, index: 413
+station name: 8th Ave, index: 414
+station name: Fort Hamilton Pkwy, index: 415
+station name: 62nd St - New Utrecht Ave, index: 283
+station name: 18th Ave, index: 416
+station name: 20th Ave, index: 417
+station name: Bay Pkwy, index: 418
+station name: Kings Highway, index: 419
+station name: Ave U, index: 420
+station name: 86th St, index: 421
+station name: Coney Island - Stillwell Ave, index: 291
 
 Line: Q
-station name: 96th St, index: 472
-station name: 86th St, index: 471
-station name: 72nd St, index: 470
-station name: Lexington Ave - 63rd St, index: 350
-station name: 49th St, index: 353
-station name: Times Sq - 42nd St, index: 79
-station name: Canal St, index: 434
-station name: DeKalb Ave, index: 14
-station name: Atlantic Ave - Barclays Ctr, index: 120
-station name: Prospect Park, index: 60
-station name: Parkside Ave, index: 113
-station name: Church Ave, index: 111
-station name: Beverley Rd, index: 110
-station name: Cortelyou Rd, index: 460
-station name: Newkirk Plaza, index: 112
-station name: Ave H, index: 343
-station name: Ave J, index: 342
-station name: Ave M, index: 339
-station name: Kings Highway, index: 329
-station name: Ave U, index: 328
-station name: Neck Rd, index: 344
-station name: Sheepshead Bay, index: 327
-station name: Brighton Beach, index: 326
-station name: Ocean Pkwy, index: 99
-station name: W Eighth St - New York Aquarium, index: 197
-station name: Coney Island - Stillwell Ave, index: 468
+station name: 96th St, index: 422
+station name: 86th St, index: 423
+station name: 72nd St, index: 424
+station name: 59th St - Lexington Ave - 63rd St, index: 110
+station name: 57th St - 7 Ave, index: 411
+station name: Times Sq - 42nd St, index: 25
+station name: 34th St - Herald Sq, index: 233
+station name: 14th St - Union Sq, index: 111
+station name: Canal St, index: 152
+station name: DeKalb Ave, index: 246
+station name: Atlantic Ave - Barclays Ctr, index: 70
+station name: 7 Ave, index: 247
+station name: Prospect Park, index: 248
+station name: Parkside Ave, index: 425
+station name: Church Ave, index: 249
+station name: Beverley Rd, index: 426
+station name: Cortelyou Rd, index: 427
+station name: Newkirk Plaza, index: 250
+station name: Ave H, index: 428
+station name: Ave J, index: 429
+station name: Ave M, index: 430
+station name: Kings Highway, index: 251
+station name: Ave U, index: 431
+station name: Neck Rd, index: 432
+station name: Sheepshead Bay, index: 252
+station name: Brighton Beach, index: 253
+station name: Ocean Pkwy, index: 433
+station name: W Eighth St - New York Aquarium, index: 333
+station name: Coney Island - Stillwell Ave, index: 291
 
 Line: R
-station name: Forest Hills - 71st Ave, index: 244
-station name: 67th Ave, index: 66
-station name: 63rd Drive - Rego Park, index: 190
-station name: Grand Ave - Newtown, index: 67
-station name: Elmhurst Ave, index: 36
-station name: Jackson Heights - Roosevelt Ave, index: 437
-station name: 65th St, index: 8
-station name: Northern Boulevard, index: 237
-station name: 46th St, index: 236
-station name: Steinway St, index: 298
-station name: 36th St, index: 9
-station name: Queens Plaza, index: 306
-station name: Lexington Ave / 59th St, index: 356
-station name: Fifth Ave / 59th St, index: 355
-station name: 49th St, index: 353
-station name: Times Sq - 42nd St, index: 79
-station name: 28th St, index: 143
-station name: 23rd St, index: 379
-station name: Prince St, index: 399
-station name: Canal St, index: 416
-station name: City Hall, index: 415
-station name: Cortlandt St, index: 428
-station name: Rector St, index: 421
-station name: Whitehall St - South Ferry, index: 420
-station name: Canal St, index: 416
-station name: Court St, index: 377
-station name: Jay St - MetroTech, index: 376
-station name: DeKalb Ave, index: 14
-station name: Atlantic Ave - Barclays Ctr, index: 121
-station name: Union St, index: 35
-station name: Prospect Ave, index: 380
-station name: 25th St, index: 392
-station name: 36th St, index: 9
-station name: 45th St, index: 387
-station name: 53rd St, index: 390
-station name: 59th St, index: 386
-station name: Bay Ridge Ave, index: 309
-station name: 77th St, index: 308
-station name: 86th St, index: 317
-station name: Bay Ridge - 95th St, index: 316
-
-Line: Z
-station name: Sutphin Boulevard - Archer Ave - JFK Airport, index: 64
-station name: 121st St, index: 209
-station name: Woodhaven Boulevard, index: 207
-station name: 75th St - Elderts Lane, index: 228
-station name: Crescent St, index: 226
-station name: Norwood Ave, index: 12
-station name: Van Siclen Ave, index: 11
-station name: Broadway Junction, index: 223
-station name: Chauncey St, index: 34
-station name: Gates Ave, index: 300
-station name: Myrtle Ave, index: 372
-station name: Marcy Ave, index: 138
-station name: Bowery, index: 433
-station name: Canal St, index: 414
-station name: Chambers St, index: 413
-station name: Fulton St, index: 412
-station name: Broad St, index: 427
+station name: Forest Hills - 71st Ave, index: 298
+station name: 67th Ave, index: 388
+station name: 63rd Drive - Rego Park, index: 389
+station name: Woodhaven Blvd, index: 390
+station name: Grand Ave - Newtown, index: 391
+station name: Elmhurst Ave, index: 392
+station name: Jackson Heights - Roosevelt Ave, index: 160
+station name: 65th St, index: 393
+station name: Northern Boulevard, index: 394
+station name: 46th St, index: 395
+station name: Steinway St, index: 396
+station name: 36th St, index: 278
+station name: Queens Plaza, index: 299
+station name: Lexington Ave / 59th St, index: 110
+station name: Fifth Ave / 59th St, index: 410
+station name: 57th St - 7 Ave, index: 411
+station name: 49th St, index: 412
+station name: Times Sq - 42nd St, index: 25
+station name: 34th St - Herald Sq, index: 233
+station name: 28th St, index: 434
+station name: 23rd St, index: 435
+station name: 14th St - Union Sq, index: 111
+station name: 8th St - NYU, index: 436
+station name: Prince St, index: 437
+station name: Canal St, index: 152
+station name: City Hall, index: 438
+station name: Cortlandt St, index: 439
+station name: Rector St, index: 440
+station name: Whitehall St - South Ferry, index: 441
+station name: Borough Hall - Court St, index: 67 
+station name: Jay St - MetroTech, index: 186
+station name: DeKalb Ave, index: 246
+station name: Atlantic Ave - Barclays Ctr, index: 70
+station name: Union St, index: 442
+station name: 4th Ave - 9th St, index: 318
+station name: Prospect Ave, index: 443
+station name: 25th St, index: 444
+station name: 36th St, index: 397
+station name: 45th St, index: 445
+station name: 53rd St, index: 446
+station name: 59th St, index: 413
+station name: Bay Ridge Ave, index: 447
+station name: 77th St, index: 448
+station name: 86th St, index: 449
+station name: Bay Ridge - 95th St, index: 450
 

--- a/lineDataOLD.txt
+++ b/lineDataOLD.txt
@@ -1,0 +1,764 @@
+Line: 1
+station name: Van Cortlandt Park - 242nd St, index: 270
+station name: 238th St, index: 5
+station name: 231st St, index: 266
+station name: Marble Hill - 225th St, index: 265
+station name: 215th St, index: 267
+station name: 207th St, index: 268
+station name: Dyckman St, index: 285
+station name: 191st St, index: 178
+station name: 181st St, index: 177
+station name: 168th St, index: 176
+station name: 157th St, index: 156
+station name: 145th St, index: 155
+station name: 137th St - City College, index: 171
+station name: 125th St, index: 286
+station name: 116th St - Columbia University, index: 166
+station name: Cathedral Pkwy (110th St), index: 165
+station name: 103rd St, index: 158
+station name: 96th St, index: 157
+station name: 86th St, index: 85
+station name: 79th St, index: 192
+station name: 72nd St, index: 161
+station name: 66th St - Lincoln Ctr, index: 87
+station name: 59th St - Columbus Circle, index: 93
+station name: 50th St, index: 2
+station name: Times Sq - 42nd St, index: 358
+station name: 34th St - Penn Station, index: 357
+station name: 28th St, index: 198
+station name: 23rd St, index: 95
+station name: 18th St, index: 202
+station name: 14th St, index: 438
+station name: Christopher St - Sheridan Sq, index: 194
+station name: Houston St, index: 96
+station name: Canal St, index: 89
+station name: Franklin St, index: 463
+station name: Chambers St, index: 403
+station name: WTC Cortlandt, index: 425
+station name: Rector St, index: 424
+station name: South Ferry, index: 417
+station name: South Ferry, index: 417
+
+Line: 2
+station name: Wakefield - 241st St, index: 279
+station name: 233rd St, index: 86
+station name: 225th St, index: 247
+station name: 219th St, index: 272
+station name: Gun Hill Rd, index: 39
+station name: Burke Ave, index: 275
+station name: Allerton Ave, index: 256
+station name: Pelham Pkwy, index: 38
+station name: Bronx Park E, index: 43
+station name: E 180th St, index: 284
+station name: W Farms Sq - E Tremont Ave, index: 271
+station name: 174th St, index: 255
+station name: Freeman St, index: 17
+station name: Simpson St, index: 42
+station name: Intervale Ave, index: 18
+station name: Prospect Ave, index: 253
+station name: Jackson Ave, index: 252
+station name: 3rd Ave - 149th St, index: 289
+station name: 149th St - Grand Concourse, index: 288
+station name: 135th St, index: 168
+station name: 125th St, index: 167
+station name: 116th St, index: 169
+station name: Central Park North (110th St), index: 159
+station name: 96th St, index: 157
+station name: 86th St, index: 85
+station name: 79th St, index: 192
+station name: 72nd St, index: 161
+station name: 66th St - Lincoln Ctr, index: 87
+station name: 59th St - Columbus Circle, index: 93
+station name: 50th St, index: 2
+station name: Times Sq - 42nd St, index: 358
+station name: 34th St - Penn Station, index: 357
+station name: 28th St, index: 198
+station name: 23rd St, index: 95
+station name: 18th St, index: 202
+station name: 14th St, index: 438
+station name: Christopher St - Sheridan Sq, index: 194
+station name: Houston St, index: 96
+station name: Canal St, index: 89
+station name: Franklin St, index: 463
+station name: Chambers St, index: 403
+station name: Park Pl, index: 402
+station name: Fulton St, index: 401
+station name: Wall St, index: 429
+station name: Clark St, index: 445
+station name: Borough Hall, index: 405
+station name: Hoyt St, index: 404
+station name: Nevins St, index: 127
+station name: Atlantic Ave - Barclays Ctr, index: 115
+station name: Bergen St, index: 3
+station name: Grand Army Plaza, index: 114
+station name: Eern Pkwy - Brooklyn Museum, index: 128
+station name: Franklin Ave, index: 41
+station name: President St, index: 454
+station name: Sterling St, index: 133
+station name: Winthrop St, index: 44
+station name: Church Ave, index: 130
+station name: Beverly Rd, index: 129
+station name: Newkirk Ave, index: 131
+
+Line: 3
+station name: Harlem - 148th St, index: 260
+station name: 145th St, index: 172
+station name: 135th St, index: 168
+station name: 125th St, index: 167
+station name: 116th St, index: 169
+station name: Central Park North (110th St), index: 159
+station name: 96th St, index: 157
+station name: 72nd St, index: 161
+station name: Times Sq - 42nd St, index: 358
+station name: 34th St - Penn Station, index: 357
+station name: 14th St, index: 438
+station name: Chambers St, index: 403
+station name: Park Pl, index: 402
+station name: Fulton St, index: 401
+station name: Wall St, index: 429
+station name: Clark St, index: 445
+station name: Borough Hall, index: 405
+station name: Hoyt St, index: 404
+station name: Nevins St, index: 127
+station name: Atlantic Ave - Barclays Ctr, index: 115
+station name: Bergen St, index: 3
+station name: Grand Army Plaza, index: 114
+station name: Eern Pkwy - Brooklyn Museum, index: 128
+station name: Franklin Ave, index: 41
+station name: Nostrand Ave, index: 444
+station name: Kingston Ave, index: 135
+station name: Crown Heights - Utica Ave, index: 134
+station name: Sutter Ave - Rutland Rd, index: 221
+station name: Saratoga Ave, index: 220
+station name: Rockaway Ave, index: 217
+station name: Junius St, index: 216
+station name: Pennsylvania Ave, index: 4
+station name: Van Siclen Ave, index: 45
+station name: New Lots Ave, index: 212
+
+Line: 4
+station name: Woodlawn, index: 455
+station name: Mosholu Pkwy, index: 273
+station name: Bedford Park Boulevard - Lehman College, index: 259
+station name: Kingsbridge Rd, index: 258
+station name: Fordham Rd, index: 407
+station name: 183rd St, index: 406
+station name: Burnside Ave, index: 174
+station name: 176th St, index: 173
+station name: Mount Eden Ave, index: 261
+station name: 170th St, index: 263
+station name: 167th St, index: 290
+station name: 161st St - Yankee Stadium, index: 47
+station name: 149th St - Grand Concourse, index: 46
+station name: 138th St - Grand Concourse, index: 140
+station name: 125th St, index: 467
+station name: 116th St, index: 461
+station name: 110th St, index: 449
+station name: 103rd St, index: 457
+station name: 96th St, index: 32
+station name: 86th St, index: 450
+station name: 77th St, index: 33
+station name: 68th St - Hunter College, index: 101
+station name: 51st St, index: 84
+station name: Grand Central - 42nd St, index: 30
+station name: 33rd St, index: 31
+station name: 28th St, index: 199
+station name: 23rd St, index: 91
+station name: Astor Pl, index: 0
+station name: Bleecker St, index: 456
+station name: Spring St, index: 466
+station name: Canal St, index: 1
+station name: Brooklyn Bridge - City Hall, index: 28
+station name: Fulton St, index: 426
+station name: Wall St, index: 419
+station name: Bowling Green, index: 418
+station name: Borough Hall, index: 122
+station name: Nevins St, index: 127
+station name: Atlantic Ave - Barclays Ctr, index: 115
+station name: Bergen St, index: 3
+station name: Grand Army Plaza, index: 114
+station name: Eern Pkwy - Brooklyn Museum, index: 128
+station name: Franklin Ave, index: 41
+station name: Nostrand Ave, index: 444
+station name: Kingston Ave, index: 135
+station name: Crown Heights - Utica Ave, index: 134
+
+Line: 5
+station name: 233rd St, index: 86
+station name: 225th St, index: 247
+station name: 219th St, index: 272
+station name: Gun Hill Rd, index: 39
+station name: Burke Ave, index: 275
+station name: Allerton Ave, index: 256
+station name: Pelham Pkwy, index: 38
+station name: Bronx Park E, index: 43
+station name: Echester - Dyre Ave, index: 277
+station name: Baychester Ave, index: 276
+station name: Gun Hill Rd, index: 39
+station name: Pelham Pkwy, index: 38
+station name: Morris Park, index: 124
+station name: E 180th St, index: 284
+station name: W Farms Sq - E Tremont Ave, index: 271
+station name: 174th St, index: 255
+station name: Freeman St, index: 17
+station name: Simpson St, index: 42
+station name: Intervale Ave, index: 18
+station name: Prospect Ave, index: 253
+station name: Jackson Ave, index: 252
+station name: 3rd Ave - 149th St, index: 289
+station name: 149th St - Grand Concourse, index: 288
+station name: 138th St - Grand Concourse, index: 140
+station name: 125th St, index: 467
+station name: 86th St, index: 450
+station name: Grand Central - 42nd St, index: 30
+station name: Brooklyn Bridge - City Hall, index: 28
+station name: Fulton St, index: 426
+station name: Wall St, index: 419
+station name: Bowling Green, index: 418
+station name: Borough Hall, index: 122
+station name: Nevins St, index: 127
+station name: Atlantic Ave - Barclays Ctr, index: 115
+station name: Franklin Ave, index: 41
+station name: President St, index: 454
+station name: Sterling St, index: 133
+station name: Winthrop St, index: 44
+station name: Church Ave, index: 130
+station name: Beverly Rd, index: 129
+station name: Newkirk Ave, index: 131
+
+Line: 6
+station name: Buhre Ave, index: 25
+station name: Middletown Rd, index: 90
+station name: Wchester Sq - E Tremont Ave, index: 201
+station name: Zerega Ave, index: 29
+station name: Castle Hill Ave, index: 27
+station name: Parkchester, index: 462
+station name: St. Lawrence Ave, index: 52
+station name: Morrison Ave - Soundview, index: 50
+station name: Elder Ave, index: 248
+station name: Whitlock Ave, index: 51
+station name: Hunts Point Ave, index: 88
+station name: Longwood Ave, index: 249
+station name: E 149th St, index: 49
+station name: E 143rd St - St. Mary's St, index: 257
+station name: Cypress Ave, index: 254
+station name: Brook Ave, index: 291
+station name: 3rd Ave - 138th St, index: 26
+station name: 125th St, index: 467
+station name: 116th St, index: 461
+station name: 110th St, index: 449
+station name: 103rd St, index: 457
+station name: 96th St, index: 32
+station name: 86th St, index: 450
+station name: 77th St, index: 33
+station name: 68th St - Hunter College, index: 101
+station name: 51st St, index: 84
+station name: Grand Central - 42nd St, index: 30
+station name: 33rd St, index: 31
+station name: 28th St, index: 199
+station name: 23rd St, index: 91
+station name: Astor Pl, index: 0
+station name: Bleecker St, index: 456
+station name: Spring St, index: 466
+station name: Canal St, index: 1
+station name: Brooklyn Bridge - City Hall, index: 28
+
+Line: 7
+station name: Mets - Willets Point, index: 22
+station name: 111th St, index: 189
+station name: 103rd St - Corona Plaza, index: 188
+station name: Junction Boulevard, index: 23
+station name: 90th St - Elmhurst Ave, index: 240
+station name: 82nd St - Jackson Heights, index: 239
+station name: 74th St - Broadway, index: 230
+station name: 69th St, index: 229
+station name: 52nd St, index: 235
+station name: 33rd St - Rawson St, index: 239
+station name: Queensboro Plaza, index: 102
+station name: Court Sq, index: 92
+station name: Hunters Point Ave, index: 94
+station name: Vernon Boulevard - Jackson Ave, index: 100
+station name: Grand Central, index: 203
+station name: Times Sq, index: 196
+station name: 34th St - Hudson Yards, index: 469
+station name: 14th St - Hudson Terminal, index: 469
+
+Line: A
+station name: Inwood - 207th St, index: 269
+station name: Dyckman St, index: 430
+station name: 190th St, index: 396
+station name: 181st St, index: 395
+station name: 175th St, index: 179
+station name: 168th St, index: 57
+station name: 163rd St - Amsterdam Ave, index: 411
+station name: 155th St, index: 410
+station name: 145th St, index: 294
+station name: 135th St, index: 439
+station name: 125th St, index: 398
+station name: 116th St, index: 397
+station name: Cathedral Pkwy (110th St), index: 6
+station name: 103rd St, index: 160
+station name: 96th St, index: 56
+station name: 86th St, index: 164
+station name: 72nd St, index: 55
+station name: 59th St - Columbus Circle, index: 352
+station name: 50th St, index: 346
+station name: 42nd St-Port Authority Bus Terminal, index: 361
+station name: 34th St - Penn Station, index: 436
+station name: 23rd St, index: 435
+station name: 14th St, index: 443
+station name: W Fourth St - Washington Sq, index: 205
+station name: Spring St, index: 394
+station name: Chambers St, index: 360
+station name: Fulton St, index: 359
+station name: High St, index: 452
+station name: Jay St - MetroTech, index: 367
+station name: Hoyt - Schermerhorn Sts, index: 366
+station name: Lafayette Ave, index: 453
+station name: Clinton - Washington Aves, index: 447
+station name: Franklin Ave, index: 446
+station name: Nostrand Ave, index: 126
+station name: Kingston - Throop Aves, index: 7
+station name: Utica Ave, index: 297
+station name: Ralph Ave, index: 37
+station name: Rockaway Ave, index: 116
+station name: Broadway Junction, index: 385
+station name: Liberty Ave, index: 384
+station name: Van Siclen Ave, index: 213
+station name: Shepherd Ave, index: 225
+station name: Euclid Ave, index: 458
+station name: Grant Ave, index: 191
+station name: 80th St, index: 464
+station name: 88th St, index: 459
+station name: Rockaway Boulevard, index: 103
+station name: 104th St, index: 97
+station name: 111th St, index: 82
+station name: Ozone Park - Lefferts Boulevard, index: 195
+station name: Aqueduct Racetrack, index: 123
+station name: Aqueduct - North Conduit Ave, index: 242
+station name: Howard Beach - JFK Airport, index: 241
+station name: Broad Channel, index: 98
+station name: Beach 67th St, index: 204
+station name: Beach 60th St, index: 181
+station name: Beach 44th St, index: 180
+station name: Beach 36th St, index: 184
+station name: Beach 25th St, index: 185
+station name: Far Rockaway - Mott Ave, index: 54
+station name: Beach 90th St, index: 16
+station name: Beach 98th St, index: 182
+station name: Beach 105th St, index: 15
+station name: Rockaway Park - Beach 116th St, index: 183
+
+Line: B
+station name: Bedford Park Boulevard, index: 264
+station name: Kingsbridge Rd, index: 58
+station name: Fordham Rd, index: 262
+station name: 182nd - 183rd Sts, index: 19
+station name: Tremont Ave, index: 170
+station name: 174th - 175th Sts, index: 20
+station name: 170th St, index: 175
+station name: 167th St, index: 21
+station name: 161st St - Yankee Stadium, index: 296
+station name: 155th St, index: 295
+station name: 145th St, index: 294
+station name: 135th St, index: 439
+station name: 125th St, index: 398
+station name: 116th St, index: 397
+station name: Cathedral Pkwy (110th St), index: 6
+station name: 103rd St, index: 160
+station name: 96th St, index: 56
+station name: 86th St, index: 164
+station name: 72nd St, index: 55
+station name: 59th St - Columbus Circle, index: 352
+station name: 47th - 50th Sts - Rockefeller Ctr, index: 348
+station name: 42nd St - Bryant Park, index: 59
+station name: Broadway - Lafayette St, index: 432
+station name: Grand St, index: 431
+station name: DeKalb Ave, index: 14
+station name: Atlantic Ave - Barclays Ctr, index: 120
+station name: Prospect Park, index: 60
+station name: Church Ave, index: 111
+station name: Newkirk Ave, index: 112
+station name: Kings Highway, index: 329
+station name: Sheepshead Bay, index: 327
+station name: Brighton Beach, index: 326
+
+Line: C
+station name: 168th St, index: 57
+station name: 163rd St - Amsterdam Ave, index: 411
+station name: 155th St, index: 410
+station name: 145th St, index: 294
+station name: 135th St, index: 439
+station name: 125th St, index: 398
+station name: 116th St, index: 397
+station name: Cathedral Pkwy (110th St), index: 6
+station name: 103rd St, index: 160
+station name: 96th St, index: 56
+station name: 86th St, index: 164
+station name: 72nd St, index: 55
+station name: 59th St - Columbus Circle, index: 352
+station name: 50th St, index: 346
+station name: 42nd St-Port Authority Bus Terminal, index: 361
+station name: 34th St - Penn Station, index: 436
+station name: 23rd St, index: 435
+station name: 14th St, index: 443
+station name: W Fourth St - Washington Sq, index: 205
+station name: Spring St, index: 394
+station name: Chambers St, index: 360
+station name: Fulton St, index: 359
+station name: High St, index: 452
+station name: Jay St - MetroTech, index: 367
+station name: Hoyt - Schermerhorn Sts, index: 366
+station name: Lafayette Ave, index: 453
+station name: Clinton - Washington Aves, index: 447
+station name: Franklin Ave, index: 446
+station name: Nostrand Ave, index: 126
+station name: Kingston - Throop Aves, index: 7
+station name: Utica Ave, index: 297
+station name: Ralph Ave, index: 37
+station name: Rockaway Ave, index: 116
+station name: Broadway Junction, index: 385
+station name: Liberty Ave, index: 384
+station name: Van Siclen Ave, index: 213
+station name: Shepherd Ave, index: 225
+station name: Euclid Ave, index: 458
+
+Line: D
+station name: Norwood - 205th St, index: 274
+station name: Bedford Park Boulevard, index: 264
+station name: Kingsbridge Rd, index: 58
+station name: Fordham Rd, index: 262
+station name: 182nd - 183rd Sts, index: 19
+station name: Tremont Ave, index: 170
+station name: 174th - 175th Sts, index: 20
+station name: 170th St, index: 175
+station name: 167th St, index: 21
+station name: 161st St - Yankee Stadium, index: 296
+station name: 155th St, index: 295
+station name: 145th St, index: 294
+station name: 125th St, index: 398
+station name: 59th St - Columbus Circle, index: 352
+station name: 47th - 50th Sts - Rockefeller Ctr, index: 348
+station name: 42nd St - Bryant Park, index: 59
+station name: Broadway - Lafayette St, index: 432
+station name: Grand St, index: 431
+station name: DeKalb Ave, index: 14
+station name: Atlantic Ave - Barclays Ctr, index: 121
+station name: Union St, index: 35
+station name: Prospect Ave, index: 380
+station name: 25th St, index: 392
+station name: 36th St, index: 388
+station name: Ninth Ave, index: 389
+station name: Fort Hamilton Pkwy, index: 391
+station name: 50th St, index: 310
+station name: 55th St, index: 61
+station name: 62nd St, index: 322
+station name: 71st St, index: 319
+station name: 79th St, index: 318
+station name: 18th Ave, index: 321
+station name: 20th Ave, index: 320
+station name: Bay Pkwy, index: 313
+station name: 25th Ave, index: 312
+station name: Bay 50th St, index: 334
+station name: Coney Island - Stillwell Ave, index: 468
+
+Line: E
+station name: Jamaica Ctr - Parsons / Archer, index: 246
+station name: Sutphin Boulevard - Archer Ave - JFK Airport, index: 64
+station name: Jamaica - Van Wyck, index: 62
+station name: Briarwood - Van Wyck Boulevard, index: 243
+station name: Kew Gardens - Union Turnpike, index: 63
+station name: 75th Ave, index: 163
+station name: Forest Hills - 71st Ave, index: 244
+station name: 67th Ave, index: 66
+station name: 63rd Drive - Rego Park, index: 190
+station name: Grand Ave - Newtown, index: 67
+station name: Elmhurst Ave, index: 36
+station name: Jackson Heights - Roosevelt Ave, index: 437
+station name: 65th St, index: 8
+station name: Northern Boulevard, index: 237
+station name: 46th St, index: 236
+station name: Steinway St, index: 298
+station name: 36th St, index: 9
+station name: Queens Plaza, index: 306
+station name: Court Sq - 23rd St, index: 65
+station name: Lexington Ave - 53rd St, index: 142
+station name: Fifth Ave / 53rd St , index: 141
+station name: 50th St, index: 346
+station name: 42nd St - Port Authority Bus Terminal, index: 361
+station name: 34th St - Penn Station, index: 436
+station name: 23rd St, index: 435
+station name: 14th St, index: 443
+station name: W Fourth St - Washington Sq, index: 205
+station name: Spring St, index: 394
+station name: World Trade Ctr, index: 408
+
+Line: F
+station name: Jamaica - 179th St, index: 278
+station name: 169th St, index: 187
+station name: Parsons Boulevard, index: 186
+station name: Sutphin Boulevard, index: 245
+station name: Briarwood - Van Wyck Boulevard, index: 243
+station name: Kew Gardens - Union Turnpike, index: 63
+station name: 75th Ave, index: 163
+station name: Forest Hills - 71st Ave, index: 244
+station name: Jackson Heights - Roosevelt Ave, index: 437
+station name: 21st St - Queensbridge, index: 345
+station name: Roosevelt Island, index: 351
+station name: Lexington Ave - 63rd St, index: 350
+station name: 47th - 50th Sts - Rockefeller Ctr, index: 348
+station name: 42nd St - Bryant Park, index: 59
+station name: 23rd St, index: 364
+station name: 14th St, index: 440
+station name: Broadway - Lafayette St, index: 432
+station name: York St, index: 451
+station name: Jay St - MetroTech, index: 367
+station name: Bergen St, index: 375
+station name: Carroll St, index: 393
+station name: Smith - Ninth Sts, index: 374
+station name: 15th St - Prospect Park, index: 106
+station name: Fort Hamilton Pkwy, index: 108
+station name: Church Ave, index: 109
+station name: Ditmas Ave, index: 68
+station name: 18th Ave, index: 307
+station name: Ave I, index: 341
+station name: Bay Pkwy, index: 338
+station name: Ave N, index: 337
+station name: Ave P, index: 336
+station name: Kings Highway, index: 325
+station name: Ave U, index: 324
+station name: Ave X, index: 333
+station name: Neptune Ave, index: 332
+station name: W Eighth St - New York Aquarium, index: 197
+station name: Coney Island - Stillwell Ave, index: 468
+
+Line: G
+station name: 21st St, index: 153
+station name: Greenpoint Ave, index: 137
+station name: Nassau Ave, index: 136
+station name: Metropolitan Ave, index: 147
+station name: Broadway, index: 70
+station name: Flushing Ave, index: 363
+station name: Myrtle - Willoughby Aves, index: 362
+station name: Bedford - Nostrand Aves, index: 105
+station name: Classon Ave, index: 69
+station name: Clinton - Washington Aves, index: 118
+station name: Fulton St, index: 117
+station name: Hoyt - Schermerhorn Sts, index: 366
+station name: Bergen St, index: 375
+station name: Carroll St, index: 393
+station name: Smith - Ninth Sts, index: 374
+station name: 15th St - Prospect Park, index: 106
+station name: Fort Hamilton Pkwy, index: 108
+station name: Church Ave, index: 109
+
+Line: J
+station name: Sutphin Boulevard - Archer Ave - JFK Airport, index: 64
+station name: 121st St, index: 209
+station name: 111th St, index: 208
+station name: Woodhaven Boulevard, index: 207
+station name: 85th St - Forest Pkwy, index: 206
+station name: 75th St - Elderts Lane, index: 228
+station name: Cypress Hills, index: 227
+station name: Crescent St, index: 226
+station name: Norwood Ave, index: 12
+station name: Cleveland St, index: 214
+station name: Van Siclen Ave, index: 11
+station name: Alabama Ave, index: 224
+station name: Broadway Junction, index: 223
+station name: Chauncey St, index: 34
+station name: Halsey St, index: 74
+station name: Gates Ave, index: 300
+station name: Kosciuszko St, index: 299
+station name: Myrtle Ave, index: 372
+station name: Flushing Ave, index: 371
+station name: Lorimer St, index: 75
+station name: Hewes St, index: 139
+station name: Marcy Ave, index: 138
+station name: Bowery, index: 433
+station name: Canal St, index: 414
+station name: Chambers St, index: 413
+station name: Fulton St, index: 412
+station name: Broad St, index: 427
+
+Line: L
+station name: 3rd Ave, index: 382
+station name: Bedford Ave, index: 150
+station name: Lorimer St, index: 71
+station name: Graham Ave, index: 149
+station name: Grand St, index: 148
+station name: Montrose Ave, index: 151
+station name: Morgan Ave, index: 305
+station name: Jefferson St, index: 304
+station name: DeKalb Ave, index: 234
+station name: Myrtle - Wyckoff Aves, index: 211
+station name: Halsey St, index: 210
+station name: Wilson Ave, index: 73
+station name: Bushwick Ave - Aberdeen St, index: 281
+station name: Broadway Junction, index: 282
+station name: Atlantic Ave, index: 193
+station name: Sutter Ave, index: 72
+station name: Livonia Ave, index: 215
+station name: New Lots Ave, index: 222
+station name: E 105th St, index: 219
+station name: Canarsie - Rockaway Pkwy, index: 218
+
+Line: M
+station name: Forest Hills - 71st Ave, index: 244
+station name: 67th Ave, index: 66
+station name: 63rd Drive - Rego Park, index: 190
+station name: Grand Ave - Newtown, index: 67
+station name: Elmhurst Ave, index: 36
+station name: Jackson Heights - Roosevelt Ave, index: 437
+station name: 65th St, index: 8
+station name: Northern Boulevard, index: 237
+station name: 46th St, index: 236
+station name: Steinway St, index: 298
+station name: 36th St, index: 9
+station name: Queens Plaza, index: 306
+station name: Court Sq - 23rd St, index: 65
+station name: Lexington Ave - 53rd St, index: 142
+station name: Fifth Ave / 53rd St, index: 141
+station name: 47th - 50th Sts - Rockefeller Ctr, index: 348
+station name: 42nd St - Bryant Park, index: 59
+station name: 23rd St, index: 364
+station name: 14th St, index: 440
+station name: Broadway - Lafayette St, index: 432
+station name: Marcy Ave, index: 138
+station name: Hewes St, index: 139
+station name: Lorimer St, index: 75
+station name: Flushing Ave, index: 371
+station name: Myrtle Ave, index: 372
+station name: Central Ave, index: 301
+station name: Knickerbocker Ave, index: 302
+station name: Myrtle - Wyckoff Aves, index: 232
+station name: Seneca Ave, index: 233
+station name: Forest Ave, index: 448
+station name: Fresh Pond Rd, index: 422
+station name: Middle Village - Metropolitan Ave, index: 423
+
+Line: N
+station name: Astoria - Ditmars Boulevard, index: 251
+station name: Astoria Boulevard, index: 250
+station name: 30th Ave, index: 303
+station name: Broadway, index: 78
+station name: 36th Ave, index: 77
+station name: 39th Avenu, index: 154
+station name: Queensboro Plaza, index: 102
+station name: Lexington Ave / 59th St, index: 356
+station name: Fifth Ave / 59th St, index: 355
+station name: 49th St, index: 353
+station name: Times Sq - 42nd St, index: 79
+station name: 28th St, index: 143
+station name: 23rd St, index: 379
+station name: Prince St, index: 399
+station name: Canal St, index: 434
+station name: Court St, index: 377
+station name: Jay St - MetroTech, index: 376
+station name: DeKalb Ave, index: 14
+station name: Atlantic Ave - Barclays Ctr, index: 121
+station name: Union St, index: 35
+station name: Prospect Ave, index: 380
+station name: 25th St, index: 392
+station name: 36th St, index: 388
+station name: 45th St, index: 387
+station name: 53rd St, index: 390
+station name: 59th St, index: 386
+station name: Fort Hamilton Pkwy, index: 311
+station name: New Utrecht Ave, index: 323
+station name: 18th Ave, index: 315
+station name: 20th Ave, index: 314
+station name: Bay Pkwy, index: 340
+station name: Kings Highway, index: 331
+station name: Ave U, index: 330
+station name: Coney Island - Stillwell Ave, index: 468
+
+Line: Q
+station name: 96th St, index: 472
+station name: 86th St, index: 471
+station name: 72nd St, index: 470
+station name: Lexington Ave - 63rd St, index: 350
+station name: 49th St, index: 353
+station name: Times Sq - 42nd St, index: 79
+station name: Canal St, index: 434
+station name: DeKalb Ave, index: 14
+station name: Atlantic Ave - Barclays Ctr, index: 120
+station name: Prospect Park, index: 60
+station name: Parkside Ave, index: 113
+station name: Church Ave, index: 111
+station name: Beverley Rd, index: 110
+station name: Cortelyou Rd, index: 460
+station name: Newkirk Plaza, index: 112
+station name: Ave H, index: 343
+station name: Ave J, index: 342
+station name: Ave M, index: 339
+station name: Kings Highway, index: 329
+station name: Ave U, index: 328
+station name: Neck Rd, index: 344
+station name: Sheepshead Bay, index: 327
+station name: Brighton Beach, index: 326
+station name: Ocean Pkwy, index: 99
+station name: W Eighth St - New York Aquarium, index: 197
+station name: Coney Island - Stillwell Ave, index: 468
+
+Line: R
+station name: Forest Hills - 71st Ave, index: 244
+station name: 67th Ave, index: 66
+station name: 63rd Drive - Rego Park, index: 190
+station name: Grand Ave - Newtown, index: 67
+station name: Elmhurst Ave, index: 36
+station name: Jackson Heights - Roosevelt Ave, index: 437
+station name: 65th St, index: 8
+station name: Northern Boulevard, index: 237
+station name: 46th St, index: 236
+station name: Steinway St, index: 298
+station name: 36th St, index: 9
+station name: Queens Plaza, index: 306
+station name: Lexington Ave / 59th St, index: 356
+station name: Fifth Ave / 59th St, index: 355
+station name: 49th St, index: 353
+station name: Times Sq - 42nd St, index: 79
+station name: 28th St, index: 143
+station name: 23rd St, index: 379
+station name: Prince St, index: 399
+station name: Canal St, index: 416
+station name: City Hall, index: 415
+station name: Cortlandt St, index: 428
+station name: Rector St, index: 421
+station name: Whitehall St - South Ferry, index: 420
+station name: Canal St, index: 416
+station name: Court St, index: 377
+station name: Jay St - MetroTech, index: 376
+station name: DeKalb Ave, index: 14
+station name: Atlantic Ave - Barclays Ctr, index: 121
+station name: Union St, index: 35
+station name: Prospect Ave, index: 380
+station name: 25th St, index: 392
+station name: 36th St, index: 9
+station name: 45th St, index: 387
+station name: 53rd St, index: 390
+station name: 59th St, index: 386
+station name: Bay Ridge Ave, index: 309
+station name: 77th St, index: 308
+station name: 86th St, index: 317
+station name: Bay Ridge - 95th St, index: 316
+
+Line: Z
+station name: Sutphin Boulevard - Archer Ave - JFK Airport, index: 64
+station name: 121st St, index: 209
+station name: Woodhaven Boulevard, index: 207
+station name: 75th St - Elderts Lane, index: 228
+station name: Crescent St, index: 226
+station name: Norwood Ave, index: 12
+station name: Van Siclen Ave, index: 11
+station name: Broadway Junction, index: 223
+station name: Chauncey St, index: 34
+station name: Gates Ave, index: 300
+station name: Myrtle Ave, index: 372
+station name: Marcy Ave, index: 138
+station name: Bowery, index: 433
+station name: Canal St, index: 414
+station name: Chambers St, index: 413
+station name: Fulton St, index: 412
+station name: Broad St, index: 427
+

--- a/main.cpp
+++ b/main.cpp
@@ -15,7 +15,7 @@
 // Ahn's starting point:		Far Rockaway Mott (id: 54)		2:02am
 // Ahn's ending point:			Flushing Main Street
 
-
+//CHANGED STATION INITIALIZATON BECAUSE STATION ID WAS ARBITRARY
 std::vector<Station> stations;
 std::vector<Line> lines;
 
@@ -111,58 +111,77 @@ int main(int argc, char* argv[]) {
 
     //                                                          M A N U A L   T R A V E R S A L
 
-	int c;
-    std::cout << "Please enter the id of a starting station\n";
-    int curr;
-    std::cin >> curr;
+    //TEST
 
-    int timeTravel = 0;
-	do {
+    //starting id for testing: 270
+    std::vector<int> path = testAlg(stations, 270);
+    for (int i = 0; i < path.size(); i++) {
+        std::cout << path[i];
+        if (i != path.size()-1) { std::cout << " -> "; }
+    }
+    std::cout << "\n" << std::endl;
 
-        stations[curr].setVisited(true); // the station is set as visited now
+    //starting id for testing: 22
+    //PROOF THAT GRAPH IS DISCONNECTED. vvvvvvvvvvvvv
+    std::vector<int> path2 = testAlg(stations, 22);
+    for (int i = 0; i < path2.size(); i++) {
+        std::cout << path2[i];
+        if (i != path2.size()-1) { std::cout << " -> "; }
+    }
+    std::cout << std::endl;
+
+	// int c;
+    // std::cout << "Please enter the id of a starting station\n";
+    // int curr;
+    // std::cin >> curr;
+
+    // int timeTravel = 0;
+	// do {
+
+    //     stations[curr].setVisited(true); // the station is set as visited now
         
-        std::cout << "\n\nTOTAL TIME ELAPSED: " << timeTravel << "\n";
-        std::cout << "Enter -1 to quit\n";
-        std::cout << "Your current location is " << stations[curr].getName() << " with ID " << curr << "\n";
-        std::cout << "Here are all of the following trips you can take!"<<std::endl<<std::endl;
+    //     std::cout << "\n\nTOTAL TIME ELAPSED: " << timeTravel << "\n";
+    //     std::cout << "Enter -1 to quit\n";
+    //     std::cout << "Your current location is " << stations[curr].getName() << " with ID " << curr << "\n";
+    //     std::cout << "Here are all of the following trips you can take!"<<std::endl<<std::endl;
 
 
-        // Printing out the possible trip you can take 
-        std::list<Trip> canGo = stations[curr].getTrips();
-        for (const auto &trip: canGo){
+    //     // Printing out the possible trip you can take 
+    //     std::list<Trip> canGo = stations[curr].getTrips();
+    //     for (const auto &trip: canGo){
         
-            std::cout   << "\tStart ID: "    << trip.getStart() 
-                        << "    End ID: "    << trip.getEnd() 
-                        << "    Time: "       << trip.getDuration()
-                        << "    Line: "         << trip.getLineName()  // ! what if its a walking route
-                        << "    Visited: "         << stations[trip.getEnd()].isVisited()
-                        // HEURISTIC NEEDS TWO ARGUMENTS, STARTING STATION AND ENDING STATION
-                        // manual traversal currently passes in the same station for both args
-                        // WILL NEED TO CHANGE FOR ACTUAL ALGORITHM
-                        << "    Heuristic: "       << heuristic(stations, trip.getStart(), trip.getStart()) <<  "\n";
-        }
+    //         std::cout   << "\tStart ID: "    << trip.getStart() 
+    //                     << "    End ID: "    << trip.getEnd() 
+    //                     << "    Time: "       << trip.getDuration()
+    //                     << "    Line: "         << trip.getLineName()  // ! what if its a walking route
+    //                     << "    Visited: "         << stations[trip.getEnd()].isVisited()
+    //                     // HEURISTIC NEEDS TWO ARGUMENTS, STARTING STATION AND ENDING STATION
+    //                     // manual traversal currently passes in the same station for both args
+    //                     // WILL NEED TO CHANGE FOR ACTUAL ALGORITHM
+    //                     << "    Heuristic: "       << heuristic(stations, trip.getStart(), trip.getStart()) <<  "\n";
+    //     }
 
-        std::cout << "\nEnter the ID of the station you would like to travel to"<<std::endl;
-        std::cin >> c;
+    //     std::cout << "\nEnter the ID of the station you would like to travel to"<<std::endl;
+    //     std::cin >> c;
 
-        if (c != -1) {
-            bool isInputValid = false; // used to check if user's choice is a trip option suggested
-            for (const auto &trip: canGo){
-                if (trip.getEnd() == c) {
-                    timeTravel += trip.getDuration();
-                    isInputValid = true;
-                    break;
-                }
-            }
-            if (isInputValid == false){
-                std::cout<<"---this station number is not a trip suggested above.---"<<std::endl;
-            }
-        }
+    //     if (c != -1) {
+    //         bool isInputValid = false; // used to check if user's choice is a trip option suggested
+    //         for (const auto &trip: canGo){
+    //             if (trip.getEnd() == c) {
+    //                 timeTravel += trip.getDuration();
+    //                 isInputValid = true;
+    //                 break;
+    //             }
+    //         }
+    //         if (isInputValid == false){
+    //             std::cout<<"---this station number is not a trip suggested above.---"<<std::endl;
+    //         }
+    //     }
 
 
-        curr = c;
+    //     curr = c;
 
-	} while(c != -1);
+	// } while(c != -1);
 
 }
 

--- a/station.h
+++ b/station.h
@@ -40,6 +40,9 @@ public:
 
     const std::pair<double, double>& getCords() const           {return cords;}
 
+	//Backpointer for UCS algorithm
+	Station* predecessor;
+
 private:
 	int id;
 	std::string name;

--- a/station.h
+++ b/station.h
@@ -26,6 +26,7 @@ public:
     void setVisited(bool inVisited)                             {visited = inVisited;}
     void addLine(std::pair<std::string, int> line);
 	void addHeuristic(int val) {heuristic += val;}
+	void setId(int newId) {id = newId;}
 
 	// getters
 	int getId() const 	 	 				    				{return id;}


### PR DESCRIPTION
Implemented working bfs traversal algorithm which returns shortest path tree as a vector-> route between disconnected branches is not returned, and can be found with a helper function.
Rewritten linedata.txt to be accurate, index of each station is arbitrary. NEW LINEDATA.TXT DOES NOT WORK WITH CURRENT MAIN.CPP.
Current linedata.txt has missing stations, and has some unique stations sharing the same id. Currently, it represents a disconnected graph and cannot be fully traversed by BFS.